### PR TITLE
Add script to generate "library/postgres" for stackbrew

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+declare -A aliases
+aliases=(
+	[9.3]='latest 9'
+	[8.4]='8'
+)
+
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+versions=( */ )
+versions=( "${versions[@]%/}" )
+commit="$(git log -1 --format='format:%H')"
+url='git://github.com/docker-library/postgres'
+
+echo '# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)'
+
+for version in "${versions[@]}"; do
+	fullVersion="$(grep -m1 'ENV PG_VERSION ' "$version/Dockerfile" | cut -d' ' -f3 | cut -d- -f1 | sed 's/~/-/g')"
+	versionAliases=( ${aliases[$version]} $version $fullVersion )
+	
+	echo
+	for va in "${versionAliases[@]}"; do
+		echo "$va: ${url}@${commit} $version"
+	done
+done


### PR DESCRIPTION
Example output:

``` console
$ ./generate-stackbrew-library.sh
# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)

8: git://github.com/docker-library/postgres@8e917a6ba18d0b8c654c9f699472829fdcd554f9 8.4
8.4: git://github.com/docker-library/postgres@8e917a6ba18d0b8c654c9f699472829fdcd554f9 8.4
8.4.22: git://github.com/docker-library/postgres@8e917a6ba18d0b8c654c9f699472829fdcd554f9 8.4

9.0: git://github.com/docker-library/postgres@8e917a6ba18d0b8c654c9f699472829fdcd554f9 9.0
9.0.18: git://github.com/docker-library/postgres@8e917a6ba18d0b8c654c9f699472829fdcd554f9 9.0

9.1: git://github.com/docker-library/postgres@8e917a6ba18d0b8c654c9f699472829fdcd554f9 9.1
9.1.14: git://github.com/docker-library/postgres@8e917a6ba18d0b8c654c9f699472829fdcd554f9 9.1

9.2: git://github.com/docker-library/postgres@8e917a6ba18d0b8c654c9f699472829fdcd554f9 9.2
9.2.9: git://github.com/docker-library/postgres@8e917a6ba18d0b8c654c9f699472829fdcd554f9 9.2

latest: git://github.com/docker-library/postgres@8e917a6ba18d0b8c654c9f699472829fdcd554f9 9.3
9: git://github.com/docker-library/postgres@8e917a6ba18d0b8c654c9f699472829fdcd554f9 9.3
9.3: git://github.com/docker-library/postgres@8e917a6ba18d0b8c654c9f699472829fdcd554f9 9.3
9.3.5: git://github.com/docker-library/postgres@8e917a6ba18d0b8c654c9f699472829fdcd554f9 9.3

9.4: git://github.com/docker-library/postgres@8e917a6ba18d0b8c654c9f699472829fdcd554f9 9.4
9.4-beta2: git://github.com/docker-library/postgres@8e917a6ba18d0b8c654c9f699472829fdcd554f9 9.4
```
