### PR TITLE
Run setup on "empty but in git" folders

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 if [ "$1" = 'postgres' ]; then
 	chown -R postgres "$PGDATA"
 	
-	if [ -z "$(ls -A "$PGDATA")" ]; then
+	if [ -z "$(ls -A "$PGDATA" | grep -v ^.gitkeep$)" ]; then
 		gosu postgres initdb
 		
 		sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA"/postgresql.conf


### PR DESCRIPTION
There is no way in git to add an empty folder, so a normal (looks like the default way), of doing it is to add an empty .gitkeep file.
Without an empty folder in your git project, tools like `fig` will fail mounting data.

Alternative 2 is to check for the existence of files like `postgresql.conf`, or even create a check-file only for this docker script.
