### PR TITLE
Allow settings a locale at runtime

### DIFF
--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -52,6 +52,12 @@ if [ "$1" = 'postgres' ]; then
 			done
 		fi
 	fi
+
+        if [ -n "$PG_LOCALE" ]; then
+            echo "$PG_LOCALE" >> /etc/locale.conf
+            echo "$PG_LOCALE" >> /etc/locale.gen
+            locale-gen
+        fi
 	
 	exec gosu postgres "$@"
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -52,6 +52,12 @@ if [ "$1" = 'postgres' ]; then
 			done
 		fi
 	fi
+
+	if [ -n "$PG_LOCALE")" ]; then
+            echo "$PG_LOCALE" >> /etc/locale.conf
+            echo "$PG_LOCALE" >> /etc/locale.gen
+            locale-gen
+        fi
 	
 	exec gosu postgres "$@"
 fi


### PR DESCRIPTION
If using an existing data that is set to a different locale than postgres server doesn't start.

this fix allows setting the locale at runtime.