### PR TITLE
Added POSTGRES_DB variable to optionally specify DB name

### DIFF
--- a/8.4/docker-entrypoint.sh
+++ b/8.4/docker-entrypoint.sh
@@ -30,16 +30,20 @@ if [ "$1" = 'postgres' ]; then
 		
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
-		if [ "$POSTGRES_DB" = 'postgres' ]; then
-			op='ALTER'
-		else
-			op='CREATE'
+
+		if [ ! "$POSTGRES_DB" = 'postgres' ]; then
 			gosu postgres postgres --single -jE <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
 		fi
 		
+		if [ "$POSTGRES_USER" = 'postgres' ]; then
+			op='ALTER'
+		else
+			op='CREATE'
+		fi
+
 		gosu postgres postgres --single -jE <<-EOSQL
 			$op USER "$POSTGRES_USER" WITH SUPERUSER $pass ;
 		EOSQL

--- a/8.4/docker-entrypoint.sh
+++ b/8.4/docker-entrypoint.sh
@@ -29,12 +29,13 @@ if [ "$1" = 'postgres' ]; then
 		fi
 		
 		: ${POSTGRES_USER:=postgres}
-		if [ "$POSTGRES_USER" = 'postgres' ]; then
+		: ${POSTGRES_DB:=$POSTGRES_USER}
+		if [ "$POSTGRES_DB" = 'postgres' ]; then
 			op='ALTER'
 		else
 			op='CREATE'
 			gosu postgres postgres --single -jE <<-EOSQL
-				CREATE DATABASE "$POSTGRES_USER" ;
+				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
 		fi

--- a/8.4/docker-entrypoint.sh
+++ b/8.4/docker-entrypoint.sh
@@ -31,7 +31,7 @@ if [ "$1" = 'postgres' ]; then
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
 
-		if [ ! "$POSTGRES_DB" = 'postgres' ]; then
+		if [ "$POSTGRES_DB" != 'postgres' ]; then
 			gosu postgres postgres --single -jE <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL

--- a/9.0/docker-entrypoint.sh
+++ b/9.0/docker-entrypoint.sh
@@ -30,16 +30,20 @@ if [ "$1" = 'postgres' ]; then
 		
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
-		if [ "$POSTGRES_DB" = 'postgres' ]; then
-			op='ALTER'
-		else
-			op='CREATE'
+
+		if [ ! "$POSTGRES_DB" = 'postgres' ]; then
 			gosu postgres postgres --single -jE <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
 		fi
 		
+		if [ "$POSTGRES_USER" = 'postgres' ]; then
+			op='ALTER'
+		else
+			op='CREATE'
+		fi
+
 		gosu postgres postgres --single -jE <<-EOSQL
 			$op USER "$POSTGRES_USER" WITH SUPERUSER $pass ;
 		EOSQL

--- a/9.0/docker-entrypoint.sh
+++ b/9.0/docker-entrypoint.sh
@@ -31,7 +31,7 @@ if [ "$1" = 'postgres' ]; then
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
 
-		if [ ! "$POSTGRES_DB" = 'postgres' ]; then
+		if [ "$POSTGRES_DB" != 'postgres' ]; then
 			gosu postgres postgres --single -jE <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL

--- a/9.0/docker-entrypoint.sh
+++ b/9.0/docker-entrypoint.sh
@@ -29,7 +29,7 @@ if [ "$1" = 'postgres' ]; then
 		fi
 		
 		: ${POSTGRES_USER:=postgres}
-    : ${POSTGRES_DB:=$POSTGRES_USER}
+		: ${POSTGRES_DB:=$POSTGRES_USER}
 		if [ "$POSTGRES_DB" = 'postgres' ]; then
 			op='ALTER'
 		else

--- a/9.0/docker-entrypoint.sh
+++ b/9.0/docker-entrypoint.sh
@@ -29,12 +29,13 @@ if [ "$1" = 'postgres' ]; then
 		fi
 		
 		: ${POSTGRES_USER:=postgres}
-		if [ "$POSTGRES_USER" = 'postgres' ]; then
+    : ${POSTGRES_DB:=$POSTGRES_USER}
+		if [ "$POSTGRES_DB" = 'postgres' ]; then
 			op='ALTER'
 		else
 			op='CREATE'
 			gosu postgres postgres --single -jE <<-EOSQL
-				CREATE DATABASE "$POSTGRES_USER" ;
+				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
 		fi

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -30,16 +30,20 @@ if [ "$1" = 'postgres' ]; then
 		
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
-		if [ "$POSTGRES_DB" = 'postgres' ]; then
-			op='ALTER'
-		else
-			op='CREATE'
+
+		if [ ! "$POSTGRES_DB" = 'postgres' ]; then
 			gosu postgres postgres --single -jE <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
 		fi
 		
+		if [ "$POSTGRES_USER" = 'postgres' ]; then
+			op='ALTER'
+		else
+			op='CREATE'
+		fi
+
 		gosu postgres postgres --single -jE <<-EOSQL
 			$op USER "$POSTGRES_USER" WITH SUPERUSER $pass ;
 		EOSQL

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -31,7 +31,7 @@ if [ "$1" = 'postgres' ]; then
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
 
-		if [ ! "$POSTGRES_DB" = 'postgres' ]; then
+		if [ "$POSTGRES_DB" != 'postgres' ]; then
 			gosu postgres postgres --single -jE <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -29,7 +29,7 @@ if [ "$1" = 'postgres' ]; then
 		fi
 		
 		: ${POSTGRES_USER:=postgres}
-    : ${POSTGRES_DB:=$POSTGRES_USER}
+		: ${POSTGRES_DB:=$POSTGRES_USER}
 		if [ "$POSTGRES_USER" = 'postgres' ]; then
 			op='ALTER'
 		else

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -29,12 +29,13 @@ if [ "$1" = 'postgres' ]; then
 		fi
 		
 		: ${POSTGRES_USER:=postgres}
+    : ${POSTGRES_DB:=$POSTGRES_USER}
 		if [ "$POSTGRES_USER" = 'postgres' ]; then
 			op='ALTER'
 		else
 			op='CREATE'
 			gosu postgres postgres --single -jE <<-EOSQL
-				CREATE DATABASE "$POSTGRES_USER" ;
+				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
 		fi

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -30,7 +30,7 @@ if [ "$1" = 'postgres' ]; then
 		
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
-		if [ "$POSTGRES_USER" = 'postgres' ]; then
+		if [ "$POSTGRES_DB" = 'postgres' ]; then
 			op='ALTER'
 		else
 			op='CREATE'

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -30,16 +30,20 @@ if [ "$1" = 'postgres' ]; then
 		
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
-		if [ "$POSTGRES_DB" = 'postgres' ]; then
-			op='ALTER'
-		else
-			op='CREATE'
+
+		if [ ! "$POSTGRES_DB" = 'postgres' ]; then
 			gosu postgres postgres --single -jE <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
 		fi
 		
+		if [ "$POSTGRES_USER" = 'postgres' ]; then
+			op='ALTER'
+		else
+			op='CREATE'
+		fi
+
 		gosu postgres postgres --single -jE <<-EOSQL
 			$op USER "$POSTGRES_USER" WITH SUPERUSER $pass ;
 		EOSQL

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -31,7 +31,7 @@ if [ "$1" = 'postgres' ]; then
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
 
-		if [ ! "$POSTGRES_DB" = 'postgres' ]; then
+		if [ "$POSTGRES_DB" != 'postgres' ]; then
 			gosu postgres postgres --single -jE <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -29,7 +29,7 @@ if [ "$1" = 'postgres' ]; then
 		fi
 		
 		: ${POSTGRES_USER:=postgres}
-    : ${POSTGRES_DB:=$POSTGRES_USER}
+		: ${POSTGRES_DB:=$POSTGRES_USER}
 		if [ "$POSTGRES_DB" = 'postgres' ]; then
 			op='ALTER'
 		else

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -29,12 +29,13 @@ if [ "$1" = 'postgres' ]; then
 		fi
 		
 		: ${POSTGRES_USER:=postgres}
-		if [ "$POSTGRES_USER" = 'postgres' ]; then
+    : ${POSTGRES_DB:=$POSTGRES_USER}
+		if [ "$POSTGRES_DB" = 'postgres' ]; then
 			op='ALTER'
 		else
 			op='CREATE'
 			gosu postgres postgres --single -jE <<-EOSQL
-				CREATE DATABASE "$POSTGRES_USER" ;
+				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
 		fi

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -30,16 +30,20 @@ if [ "$1" = 'postgres' ]; then
 		
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
-		if [ "$POSTGRES_DB" = 'postgres' ]; then
-			op='ALTER'
-		else
-			op='CREATE'
+
+		if [ ! "$POSTGRES_DB" = 'postgres' ]; then
 			gosu postgres postgres --single -jE <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
 		fi
 		
+		if [ "$POSTGRES_USER" = 'postgres' ]; then
+			op='ALTER'
+		else
+			op='CREATE'
+		fi
+
 		gosu postgres postgres --single -jE <<-EOSQL
 			$op USER "$POSTGRES_USER" WITH SUPERUSER $pass ;
 		EOSQL

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -31,7 +31,7 @@ if [ "$1" = 'postgres' ]; then
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
 
-		if [ ! "$POSTGRES_DB" = 'postgres' ]; then
+		if [ "$POSTGRES_DB" != 'postgres' ]; then
 			gosu postgres postgres --single -jE <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -29,7 +29,7 @@ if [ "$1" = 'postgres' ]; then
 		fi
 		
 		: ${POSTGRES_USER:=postgres}
-    : ${POSTGRES_DB:=$POSTGRES_USER}
+		: ${POSTGRES_DB:=$POSTGRES_USER}
 		if [ "$POSTGRES_DB" = 'postgres' ]; then
 			op='ALTER'
 		else

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -29,12 +29,13 @@ if [ "$1" = 'postgres' ]; then
 		fi
 		
 		: ${POSTGRES_USER:=postgres}
-		if [ "$POSTGRES_USER" = 'postgres' ]; then
+    : ${POSTGRES_DB:=$POSTGRES_USER}
+		if [ "$POSTGRES_DB" = 'postgres' ]; then
 			op='ALTER'
 		else
 			op='CREATE'
 			gosu postgres postgres --single -jE <<-EOSQL
-				CREATE DATABASE "$POSTGRES_USER" ;
+				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
 		fi

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -30,16 +30,20 @@ if [ "$1" = 'postgres' ]; then
 		
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
-		if [ "$POSTGRES_DB" = 'postgres' ]; then
-			op='ALTER'
-		else
-			op='CREATE'
+
+		if [ ! "$POSTGRES_DB" = 'postgres' ]; then
 			gosu postgres postgres --single -jE <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
 		fi
 		
+		if [ "$POSTGRES_USER" = 'postgres' ]; then
+			op='ALTER'
+		else
+			op='CREATE'
+		fi
+
 		gosu postgres postgres --single -jE <<-EOSQL
 			$op USER "$POSTGRES_USER" WITH SUPERUSER $pass ;
 		EOSQL

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -31,7 +31,7 @@ if [ "$1" = 'postgres' ]; then
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
 
-		if [ ! "$POSTGRES_DB" = 'postgres' ]; then
+		if [ "$POSTGRES_DB" != 'postgres' ]; then
 			gosu postgres postgres --single -jE <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -29,7 +29,7 @@ if [ "$1" = 'postgres' ]; then
 		fi
 		
 		: ${POSTGRES_USER:=postgres}
-    : ${POSTGRES_DB:=$POSTGRES_USER}
+		: ${POSTGRES_DB:=$POSTGRES_USER}
 		if [ "$POSTGRES_DB" = 'postgres' ]; then
 			op='ALTER'
 		else

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -29,12 +29,13 @@ if [ "$1" = 'postgres' ]; then
 		fi
 		
 		: ${POSTGRES_USER:=postgres}
-		if [ "$POSTGRES_USER" = 'postgres' ]; then
+    : ${POSTGRES_DB:=$POSTGRES_USER}
+		if [ "$POSTGRES_DB" = 'postgres' ]; then
 			op='ALTER'
 		else
 			op='CREATE'
 			gosu postgres postgres --single -jE <<-EOSQL
-				CREATE DATABASE "$POSTGRES_USER" ;
+				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
 		fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,16 +30,20 @@ if [ "$1" = 'postgres' ]; then
 		
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
-		if [ "$POSTGRES_DB" = 'postgres' ]; then
-			op='ALTER'
-		else
-			op='CREATE'
+
+		if [ ! "$POSTGRES_DB" = 'postgres' ]; then
 			gosu postgres postgres --single -jE <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
 		fi
 		
+		if [ "$POSTGRES_USER" = 'postgres' ]; then
+			op='ALTER'
+		else
+			op='CREATE'
+		fi
+
 		gosu postgres postgres --single -jE <<-EOSQL
 			$op USER "$POSTGRES_USER" WITH SUPERUSER $pass ;
 		EOSQL

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,7 +31,7 @@ if [ "$1" = 'postgres' ]; then
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
 
-		if [ ! "$POSTGRES_DB" = 'postgres' ]; then
+		if [ "$POSTGRES_DB" != 'postgres' ]; then
 			gosu postgres postgres --single -jE <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [ "$1" = 'postgres' ]; then
 		else
 			op='CREATE'
 			gosu postgres postgres --single -jE <<-EOSQL
-				CREATE DATABASE "$POSTGRES_USER" ;
+				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
 		fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,7 +29,8 @@ if [ "$1" = 'postgres' ]; then
 		fi
 		
 		: ${POSTGRES_USER:=postgres}
-		if [ "$POSTGRES_USER" = 'postgres' ]; then
+		: ${POSTGRES_DB:=$POSTGRES_USER}
+		if [ "$POSTGRES_DB" = 'postgres' ]; then
 			op='ALTER'
 		else
 			op='CREATE'


### PR DESCRIPTION
POSTGRESS_DB defaults to POSTGRESS_USER if it's not specified.

Example run

```
docker run -d --name postgres -e POSTGRES_DB=testdb -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password postgres
```

You can also connect to the db with

```
docker run --rm -it --name dbconnect --link postgres:db postgres sh -c 'exec psql -h "$DB_PORT_5432_TCP_ADDR" -p "$DB_PORT_5432_TCP_PORT" -d testdb -U postgres'
```