### PR TITLE
Make /run/postgresql a volume

### DIFF
--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -41,6 +41,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres /var/run/postgresql
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
 VOLUME /var/lib/postgresql/data
+VOLUME /run/postgresql
 
 COPY docker-entrypoint.sh /
 

--- a/8.4/docker-entrypoint.sh
+++ b/8.4/docker-entrypoint.sh
@@ -4,6 +4,9 @@ set -e
 if [ "$1" = 'postgres' ]; then
 	chown -R postgres "$PGDATA"
 	
+	chmod g+s /run/postgresql
+	chown -R postgres:postgres /run/postgresql
+	
 	if [ -z "$(ls -A "$PGDATA")" ]; then
 		gosu postgres initdb
 		

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -41,6 +41,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres /var/run/postgresql
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
 VOLUME /var/lib/postgresql/data
+VOLUME /run/postgresql
 
 COPY docker-entrypoint.sh /
 

--- a/9.0/docker-entrypoint.sh
+++ b/9.0/docker-entrypoint.sh
@@ -4,6 +4,9 @@ set -e
 if [ "$1" = 'postgres' ]; then
 	chown -R postgres "$PGDATA"
 	
+	chmod g+s /run/postgresql
+	chown -R postgres:postgres /run/postgresql
+	
 	if [ -z "$(ls -A "$PGDATA")" ]; then
 		gosu postgres initdb
 		

--- a/9.1/Dockerfile
+++ b/9.1/Dockerfile
@@ -41,6 +41,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres /var/run/postgresql
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
 VOLUME /var/lib/postgresql/data
+VOLUME /run/postgresql
 
 COPY docker-entrypoint.sh /
 

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -4,6 +4,9 @@ set -e
 if [ "$1" = 'postgres' ]; then
 	chown -R postgres "$PGDATA"
 	
+	chmod g+s /run/postgresql
+	chown -R postgres:postgres /run/postgresql
+	
 	if [ -z "$(ls -A "$PGDATA")" ]; then
 		gosu postgres initdb
 		

--- a/9.2/Dockerfile
+++ b/9.2/Dockerfile
@@ -41,6 +41,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres /var/run/postgresql
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
 VOLUME /var/lib/postgresql/data
+VOLUME /run/postgresql
 
 COPY docker-entrypoint.sh /
 

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -4,6 +4,9 @@ set -e
 if [ "$1" = 'postgres' ]; then
 	chown -R postgres "$PGDATA"
 	
+	chmod g+s /run/postgresql
+	chown -R postgres:postgres /run/postgresql
+	
 	if [ -z "$(ls -A "$PGDATA")" ]; then
 		gosu postgres initdb
 		

--- a/9.3/Dockerfile
+++ b/9.3/Dockerfile
@@ -41,6 +41,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres /var/run/postgresql
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
 VOLUME /var/lib/postgresql/data
+VOLUME /run/postgresql
 
 COPY docker-entrypoint.sh /
 

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -4,6 +4,9 @@ set -e
 if [ "$1" = 'postgres' ]; then
 	chown -R postgres "$PGDATA"
 	
+	chmod g+s /run/postgresql
+	chown -R postgres:postgres /run/postgresql
+	
 	if [ -z "$(ls -A "$PGDATA")" ]; then
 		gosu postgres initdb
 		

--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -41,6 +41,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres /var/run/postgresql
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
 VOLUME /var/lib/postgresql/data
+VOLUME /run/postgresql
 
 COPY docker-entrypoint.sh /
 

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -4,6 +4,9 @@ set -e
 if [ "$1" = 'postgres' ]; then
 	chown -R postgres "$PGDATA"
 	
+	chmod g+s /run/postgresql
+	chown -R postgres:postgres /run/postgresql
+	
 	if [ -z "$(ls -A "$PGDATA")" ]; then
 		gosu postgres initdb
 		

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -41,6 +41,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres /var/run/postgresql
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
 VOLUME /var/lib/postgresql/data
+VOLUME /run/postgresql
 
 COPY docker-entrypoint.sh /
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,6 +4,9 @@ set -e
 if [ "$1" = 'postgres' ]; then
 	chown -R postgres "$PGDATA"
 	
+	chmod g+s /run/postgresql
+	chown -R postgres:postgres /run/postgresql
+	
 	if [ -z "$(ls -A "$PGDATA")" ]; then
 		gosu postgres initdb
 		


### PR DESCRIPTION
Forgot I created this branch last week. Opening this PR for discussion as much as anything. It seems reasonable to me for service containers to use `VOLUME /run/MYSERVICE` if they have a dedicated `/run` directory.

Fixes docker-library/postgres#50