### PR TITLE
Pass important postgres settings to docker-entrypoint.sh via ENV vars

### DIFF
--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -2,9 +2,9 @@
 set -e
 
 function alter_system {
-    if [ ! -z "$2" -a "$2" != " " ]; then
-        sed -ri "s/^#?($1\s*=\s*)\S+/\1'$2'/" "$PGDATA"/postgresql.conf
-    fi
+	if [ ! -z "$2" -a "$2" != " " ]; then
+		sed -ri "s/^#?($1\s*=\s*)\S+/\1'$2'/" "$PGDATA"/postgresql.conf
+	fi
 }
 
 if [ "$1" = 'postgres' ]; then
@@ -16,15 +16,14 @@ if [ "$1" = 'postgres' ]; then
 	if [ -z "$(ls -A "$PGDATA")" ]; then
 		gosu postgres initdb
 
-        alter_system "listen_addresses" "*"
+		alter_system "listen_addresses" "*"
 
-        conf_prefix="POSTGRES_CONF_"
-        for env_name in $(env | cut -d= -f1 | grep "$conf_prefix.*"); do
-            value=$env_name
-            setting_name=${env_name#$conf_prefix}
-            setting_name=${setting_name,,}
-            alter_system $setting_name ${!value}
-        done
+		for env_name in ${!POSTGRES_CONF_*}; do
+			value=$env_name
+			setting_name=${env_name#"POSTGRES_CONF_"}
+			setting_name=${setting_name,,}
+			alter_system $setting_name ${!value}
+		done
 
 		# check password first so we can ouptut the warning before postgres
 		# messes it up

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -17,12 +17,14 @@ if [ "$1" = 'postgres' ]; then
 		gosu postgres initdb
 
         alter_system "listen_addresses" "*"
-        alter_system "shared_buffers" $POSTGRES_SHARED_BUFFERS
-        alter_system "max_connections" $POSTGRES_MAX_CONNECTIONS
-        alter_system "wal_level" $POSTGRES_WAL_LEVEL
-        alter_system "work_mem" $POSTGRES_WORK_MEM
-        alter_system "effective_cache_size" $POSTGRES_EFFECTIVE_CACHE_SIZE
-        alter_system "wal_buffers" $POSTGRES_WAL_BUFFERS
+
+        conf_prefix="POSTGRES_CONF_"
+        for env_name in $(env | cut -d= -f1 | grep "$conf_prefix.*"); do
+            value=$env_name
+            setting_name=${env_name#$conf_prefix}
+            setting_name=${setting_name,,}
+            alter_system $setting_name ${!value}
+        done
 
 		# check password first so we can ouptut the warning before postgres
 		# messes it up


### PR DESCRIPTION
Thanks for your work so far guys!

The postgres defaults are quite modest (especially memory). Most settings can nowaydays be set via the `ALTER SYSTEM` query and a reload but some settings require a restart  and therefore should be set before postgres starts.

This is just a proposal how it could be done. I would be happy to see what you think about it and which settings to include and whether it is even in the scope of this Docker image.

I think it would make quick configuration of postgres containers much easier because you don't have to create your own Docker image just for tweaking some very basic settings like `shared_buffers`.
It also allows schedulers for example to set the `shared_buffers` options based on metadata.

I simply modified the `docker-entrypoint.sh` of the latest Docker image for now, if you think it is a good idea in general I will modify the others as well.