### PR TITLE
Check that vol actually contains DB files, as opposed to a non-empty dir.

### DIFF
--- a/9.0/docker-entrypoint.sh
+++ b/9.0/docker-entrypoint.sh
@@ -9,7 +9,7 @@ if [ "$1" = 'postgres' ]; then
 	chown -R postgres:postgres /run/postgresql
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ -z "$(ls -A "$PGDATA"/PG_VERSION)" ]; then
+	if [ -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
 
 		sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA"/postgresql.conf

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -9,7 +9,7 @@ if [ "$1" = 'postgres' ]; then
 	chown -R postgres:postgres /run/postgresql
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ -z "$(ls -A "$PGDATA"/PG_VERSION)" ]; then
+	if [ -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
 
 		sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA"/postgresql.conf

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -9,7 +9,7 @@ if [ "$1" = 'postgres' ]; then
 	chown -R postgres:postgres /run/postgresql
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ -z "$(ls -A "$PGDATA"/PG_VERSION)" ]; then
+	if [ -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
 
 		sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA"/postgresql.conf

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -9,7 +9,7 @@ if [ "$1" = 'postgres' ]; then
 	chown -R postgres:postgres /run/postgresql
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ -z "$(ls -A "$PGDATA"/PG_VERSION)" ]; then
+	if [ -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
 
 		sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA"/postgresql.conf

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -9,7 +9,7 @@ if [ "$1" = 'postgres' ]; then
 	chown -R postgres:postgres /run/postgresql
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ -z "$(ls -A "$PGDATA"/PG_VERSION)" ]; then
+	if [ -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
 
 		sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA"/postgresql.conf

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -9,7 +9,7 @@ if [ "$1" = 'postgres' ]; then
 	chown -R postgres:postgres /run/postgresql
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ -z "$(ls -A "$PGDATA"/PG_VERSION)" ]; then
+	if [ -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
 
 		sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA"/postgresql.conf

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,7 +9,7 @@ if [ "$1" = 'postgres' ]; then
 	chown -R postgres:postgres /run/postgresql
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ -z "$(ls -A "$PGDATA"/PG_VERSION)" ]; then
+	if [ -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
 
 		sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA"/postgresql.conf


### PR DESCRIPTION
Part of fix for mounting persistent disks on Google Cloud Compute containers - fresh disks have a `lost+found` directory, causing the old check to fail with 

```
postgres cannot access the server configuration file "/var/lib/postgresql/data/postgresql.conf"
```

The second part of the fix requires the GCE user to adjust `PGDATA` to a subdirectory within the mounted persistent disk. If the `initdb` command is run directly on the mount point root, it fails, complaining that it is bad practice to have the database there. [Reference thread](http://postgresql.nabble.com/src-ports-pgcheckdir-c-Ignore-dot-directories-td5743755.html).

The notice to adjust `PGDATA` should be in the docs for postgres-docker.

I feel we should not make it mandatory for `PGDATA` to auto-create a subdirectory at all `VOLUME` mountpoints, as the mounted point might already be a subdirectory in the host system.