### PR TITLE
Improve initdb logic to properly source *.sql files as well, without the use of --single

### DIFF
--- a/9.0/docker-entrypoint.sh
+++ b/9.0/docker-entrypoint.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 set -e
 
+set_listen_addresses() {
+	sedEscapedValue="$(echo "$1" | sed 's/[\/&]/\\&/g')"
+	sed -ri "s/^#?(listen_addresses\s*=\s*)\S+/\1'$sedEscapedValue'/" "$PGDATA/postgresql.conf"
+}
+
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql
-	chown -R postgres:postgres /run/postgresql
+	chown -R postgres /run/postgresql
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
-
-		sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA"/postgresql.conf
 
 		# check password first so we can output the warning before postgres
 		# messes it up
@@ -39,11 +42,29 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
+		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+
+		set_listen_addresses '' # we're going to start up postgres, but it's not ready for use yet (this is initialization), so don't listen to the outside world yet
+
+		gosu postgres "$@" &
+		pid="$!"
+		for i in {30..0}; do
+			if echo 'SELECT 1' | psql --username postgres &> /dev/null; then
+				break
+			fi
+			echo 'PostgreSQL init process in progress...'
+			sleep 1
+		done
+		if [ "$i" = 0 ]; then
+			echo >&2 'PostgreSQL init process failed'
+			exit 1
+		fi
+
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
 
 		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			gosu postgres postgres --single -jE <<-EOSQL
+			psql --username postgres <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
@@ -55,18 +76,31 @@ if [ "$1" = 'postgres' ]; then
 			op='CREATE'
 		fi
 
-		gosu postgres postgres --single -jE <<-EOSQL
+		psql --username postgres <<-EOSQL
 			$op USER "$POSTGRES_USER" WITH SUPERUSER $pass ;
 		EOSQL
 		echo
 
-		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA"/pg_hba.conf
+		echo
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh)  echo "$0: running $f"; . "$f" ;;
+				*.sql) echo "$0: running $f"; psql --username postgres --dbname "$POSTGRES_DB" < "$f" && echo ;;
+				*)     echo "$0: ignoring $f" ;;
+			esac
+			echo
+		done
 
-		if [ -d /docker-entrypoint-initdb.d ]; then
-			for f in /docker-entrypoint-initdb.d/*.sh; do
-				[ -f "$f" ] && . "$f"
-			done
+		if ! kill -s TERM "$pid" || ! wait "$pid"; then
+			echo >&2 'PostgreSQL init process failed'
+			exit 1
 		fi
+
+		set_listen_addresses '*'
+
+		echo
+		echo 'PostgreSQL init process complete; ready for start up.'
+		echo
 	fi
 
 	exec gosu postgres "$@"

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 set -e
 
+set_listen_addresses() {
+	sedEscapedValue="$(echo "$1" | sed 's/[\/&]/\\&/g')"
+	sed -ri "s/^#?(listen_addresses\s*=\s*)\S+/\1'$sedEscapedValue'/" "$PGDATA/postgresql.conf"
+}
+
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql
-	chown -R postgres:postgres /run/postgresql
+	chown -R postgres /run/postgresql
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
-
-		sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA"/postgresql.conf
 
 		# check password first so we can output the warning before postgres
 		# messes it up
@@ -39,11 +42,29 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
+		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+
+		set_listen_addresses '' # we're going to start up postgres, but it's not ready for use yet (this is initialization), so don't listen to the outside world yet
+
+		gosu postgres "$@" &
+		pid="$!"
+		for i in {30..0}; do
+			if echo 'SELECT 1' | psql --username postgres &> /dev/null; then
+				break
+			fi
+			echo 'PostgreSQL init process in progress...'
+			sleep 1
+		done
+		if [ "$i" = 0 ]; then
+			echo >&2 'PostgreSQL init process failed'
+			exit 1
+		fi
+
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
 
 		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			gosu postgres postgres --single -jE <<-EOSQL
+			psql --username postgres <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
@@ -55,18 +76,31 @@ if [ "$1" = 'postgres' ]; then
 			op='CREATE'
 		fi
 
-		gosu postgres postgres --single -jE <<-EOSQL
+		psql --username postgres <<-EOSQL
 			$op USER "$POSTGRES_USER" WITH SUPERUSER $pass ;
 		EOSQL
 		echo
 
-		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA"/pg_hba.conf
+		echo
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh)  echo "$0: running $f"; . "$f" ;;
+				*.sql) echo "$0: running $f"; psql --username postgres --dbname "$POSTGRES_DB" < "$f" && echo ;;
+				*)     echo "$0: ignoring $f" ;;
+			esac
+			echo
+		done
 
-		if [ -d /docker-entrypoint-initdb.d ]; then
-			for f in /docker-entrypoint-initdb.d/*.sh; do
-				[ -f "$f" ] && . "$f"
-			done
+		if ! kill -s TERM "$pid" || ! wait "$pid"; then
+			echo >&2 'PostgreSQL init process failed'
+			exit 1
 		fi
+
+		set_listen_addresses '*'
+
+		echo
+		echo 'PostgreSQL init process complete; ready for start up.'
+		echo
 	fi
 
 	exec gosu postgres "$@"

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 set -e
 
+set_listen_addresses() {
+	sedEscapedValue="$(echo "$1" | sed 's/[\/&]/\\&/g')"
+	sed -ri "s/^#?(listen_addresses\s*=\s*)\S+/\1'$sedEscapedValue'/" "$PGDATA/postgresql.conf"
+}
+
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql
-	chown -R postgres:postgres /run/postgresql
+	chown -R postgres /run/postgresql
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
-
-		sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA"/postgresql.conf
 
 		# check password first so we can output the warning before postgres
 		# messes it up
@@ -39,11 +42,29 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
+		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+
+		set_listen_addresses '' # we're going to start up postgres, but it's not ready for use yet (this is initialization), so don't listen to the outside world yet
+
+		gosu postgres "$@" &
+		pid="$!"
+		for i in {30..0}; do
+			if echo 'SELECT 1' | psql --username postgres &> /dev/null; then
+				break
+			fi
+			echo 'PostgreSQL init process in progress...'
+			sleep 1
+		done
+		if [ "$i" = 0 ]; then
+			echo >&2 'PostgreSQL init process failed'
+			exit 1
+		fi
+
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
 
 		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			gosu postgres postgres --single -jE <<-EOSQL
+			psql --username postgres <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
@@ -55,18 +76,31 @@ if [ "$1" = 'postgres' ]; then
 			op='CREATE'
 		fi
 
-		gosu postgres postgres --single -jE <<-EOSQL
+		psql --username postgres <<-EOSQL
 			$op USER "$POSTGRES_USER" WITH SUPERUSER $pass ;
 		EOSQL
 		echo
 
-		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA"/pg_hba.conf
+		echo
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh)  echo "$0: running $f"; . "$f" ;;
+				*.sql) echo "$0: running $f"; psql --username postgres --dbname "$POSTGRES_DB" < "$f" && echo ;;
+				*)     echo "$0: ignoring $f" ;;
+			esac
+			echo
+		done
 
-		if [ -d /docker-entrypoint-initdb.d ]; then
-			for f in /docker-entrypoint-initdb.d/*.sh; do
-				[ -f "$f" ] && . "$f"
-			done
+		if ! kill -s TERM "$pid" || ! wait "$pid"; then
+			echo >&2 'PostgreSQL init process failed'
+			exit 1
 		fi
+
+		set_listen_addresses '*'
+
+		echo
+		echo 'PostgreSQL init process complete; ready for start up.'
+		echo
 	fi
 
 	exec gosu postgres "$@"

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 set -e
 
+set_listen_addresses() {
+	sedEscapedValue="$(echo "$1" | sed 's/[\/&]/\\&/g')"
+	sed -ri "s/^#?(listen_addresses\s*=\s*)\S+/\1'$sedEscapedValue'/" "$PGDATA/postgresql.conf"
+}
+
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql
-	chown -R postgres:postgres /run/postgresql
+	chown -R postgres /run/postgresql
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
-
-		sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA"/postgresql.conf
 
 		# check password first so we can output the warning before postgres
 		# messes it up
@@ -39,11 +42,29 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
+		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+
+		set_listen_addresses '' # we're going to start up postgres, but it's not ready for use yet (this is initialization), so don't listen to the outside world yet
+
+		gosu postgres "$@" &
+		pid="$!"
+		for i in {30..0}; do
+			if echo 'SELECT 1' | psql --username postgres &> /dev/null; then
+				break
+			fi
+			echo 'PostgreSQL init process in progress...'
+			sleep 1
+		done
+		if [ "$i" = 0 ]; then
+			echo >&2 'PostgreSQL init process failed'
+			exit 1
+		fi
+
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
 
 		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			gosu postgres postgres --single -jE <<-EOSQL
+			psql --username postgres <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
@@ -55,18 +76,31 @@ if [ "$1" = 'postgres' ]; then
 			op='CREATE'
 		fi
 
-		gosu postgres postgres --single -jE <<-EOSQL
+		psql --username postgres <<-EOSQL
 			$op USER "$POSTGRES_USER" WITH SUPERUSER $pass ;
 		EOSQL
 		echo
 
-		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA"/pg_hba.conf
+		echo
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh)  echo "$0: running $f"; . "$f" ;;
+				*.sql) echo "$0: running $f"; psql --username postgres --dbname "$POSTGRES_DB" < "$f" && echo ;;
+				*)     echo "$0: ignoring $f" ;;
+			esac
+			echo
+		done
 
-		if [ -d /docker-entrypoint-initdb.d ]; then
-			for f in /docker-entrypoint-initdb.d/*.sh; do
-				[ -f "$f" ] && . "$f"
-			done
+		if ! kill -s TERM "$pid" || ! wait "$pid"; then
+			echo >&2 'PostgreSQL init process failed'
+			exit 1
 		fi
+
+		set_listen_addresses '*'
+
+		echo
+		echo 'PostgreSQL init process complete; ready for start up.'
+		echo
 	fi
 
 	exec gosu postgres "$@"

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 set -e
 
+set_listen_addresses() {
+	sedEscapedValue="$(echo "$1" | sed 's/[\/&]/\\&/g')"
+	sed -ri "s/^#?(listen_addresses\s*=\s*)\S+/\1'$sedEscapedValue'/" "$PGDATA/postgresql.conf"
+}
+
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql
-	chown -R postgres:postgres /run/postgresql
+	chown -R postgres /run/postgresql
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
-
-		sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA"/postgresql.conf
 
 		# check password first so we can output the warning before postgres
 		# messes it up
@@ -39,11 +42,29 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
+		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+
+		set_listen_addresses '' # we're going to start up postgres, but it's not ready for use yet (this is initialization), so don't listen to the outside world yet
+
+		gosu postgres "$@" &
+		pid="$!"
+		for i in {30..0}; do
+			if echo 'SELECT 1' | psql --username postgres &> /dev/null; then
+				break
+			fi
+			echo 'PostgreSQL init process in progress...'
+			sleep 1
+		done
+		if [ "$i" = 0 ]; then
+			echo >&2 'PostgreSQL init process failed'
+			exit 1
+		fi
+
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
 
 		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			gosu postgres postgres --single -jE <<-EOSQL
+			psql --username postgres <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
@@ -55,18 +76,31 @@ if [ "$1" = 'postgres' ]; then
 			op='CREATE'
 		fi
 
-		gosu postgres postgres --single -jE <<-EOSQL
+		psql --username postgres <<-EOSQL
 			$op USER "$POSTGRES_USER" WITH SUPERUSER $pass ;
 		EOSQL
 		echo
 
-		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA"/pg_hba.conf
+		echo
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh)  echo "$0: running $f"; . "$f" ;;
+				*.sql) echo "$0: running $f"; psql --username postgres --dbname "$POSTGRES_DB" < "$f" && echo ;;
+				*)     echo "$0: ignoring $f" ;;
+			esac
+			echo
+		done
 
-		if [ -d /docker-entrypoint-initdb.d ]; then
-			for f in /docker-entrypoint-initdb.d/*.sh; do
-				[ -f "$f" ] && . "$f"
-			done
+		if ! kill -s TERM "$pid" || ! wait "$pid"; then
+			echo >&2 'PostgreSQL init process failed'
+			exit 1
 		fi
+
+		set_listen_addresses '*'
+
+		echo
+		echo 'PostgreSQL init process complete; ready for start up.'
+		echo
 	fi
 
 	exec gosu postgres "$@"

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 set -e
 
+set_listen_addresses() {
+	sedEscapedValue="$(echo "$1" | sed 's/[\/&]/\\&/g')"
+	sed -ri "s/^#?(listen_addresses\s*=\s*)\S+/\1'$sedEscapedValue'/" "$PGDATA/postgresql.conf"
+}
+
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql
-	chown -R postgres:postgres /run/postgresql
+	chown -R postgres /run/postgresql
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
-
-		sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA"/postgresql.conf
 
 		# check password first so we can output the warning before postgres
 		# messes it up
@@ -39,11 +42,29 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
+		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+
+		set_listen_addresses '' # we're going to start up postgres, but it's not ready for use yet (this is initialization), so don't listen to the outside world yet
+
+		gosu postgres "$@" &
+		pid="$!"
+		for i in {30..0}; do
+			if echo 'SELECT 1' | psql --username postgres &> /dev/null; then
+				break
+			fi
+			echo 'PostgreSQL init process in progress...'
+			sleep 1
+		done
+		if [ "$i" = 0 ]; then
+			echo >&2 'PostgreSQL init process failed'
+			exit 1
+		fi
+
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
 
 		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			gosu postgres postgres --single -jE <<-EOSQL
+			psql --username postgres <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
@@ -55,18 +76,31 @@ if [ "$1" = 'postgres' ]; then
 			op='CREATE'
 		fi
 
-		gosu postgres postgres --single -jE <<-EOSQL
+		psql --username postgres <<-EOSQL
 			$op USER "$POSTGRES_USER" WITH SUPERUSER $pass ;
 		EOSQL
 		echo
 
-		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA"/pg_hba.conf
+		echo
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh)  echo "$0: running $f"; . "$f" ;;
+				*.sql) echo "$0: running $f"; psql --username postgres --dbname "$POSTGRES_DB" < "$f" && echo ;;
+				*)     echo "$0: ignoring $f" ;;
+			esac
+			echo
+		done
 
-		if [ -d /docker-entrypoint-initdb.d ]; then
-			for f in /docker-entrypoint-initdb.d/*.sh; do
-				[ -f "$f" ] && . "$f"
-			done
+		if ! kill -s TERM "$pid" || ! wait "$pid"; then
+			echo >&2 'PostgreSQL init process failed'
+			exit 1
 		fi
+
+		set_listen_addresses '*'
+
+		echo
+		echo 'PostgreSQL init process complete; ready for start up.'
+		echo
 	fi
 
 	exec gosu postgres "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 set -e
 
+set_listen_addresses() {
+	sedEscapedValue="$(echo "$1" | sed 's/[\/&]/\\&/g')"
+	sed -ri "s/^#?(listen_addresses\s*=\s*)\S+/\1'$sedEscapedValue'/" "$PGDATA/postgresql.conf"
+}
+
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql
-	chown -R postgres:postgres /run/postgresql
+	chown -R postgres /run/postgresql
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
-
-		sed -ri "s/^#(listen_addresses\s*=\s*)\S+/\1'*'/" "$PGDATA"/postgresql.conf
 
 		# check password first so we can output the warning before postgres
 		# messes it up
@@ -39,11 +42,29 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
+		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+
+		set_listen_addresses '' # we're going to start up postgres, but it's not ready for use yet (this is initialization), so don't listen to the outside world yet
+
+		gosu postgres "$@" &
+		pid="$!"
+		for i in {30..0}; do
+			if echo 'SELECT 1' | psql --username postgres &> /dev/null; then
+				break
+			fi
+			echo 'PostgreSQL init process in progress...'
+			sleep 1
+		done
+		if [ "$i" = 0 ]; then
+			echo >&2 'PostgreSQL init process failed'
+			exit 1
+		fi
+
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
 
 		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			gosu postgres postgres --single -jE <<-EOSQL
+			psql --username postgres <<-EOSQL
 				CREATE DATABASE "$POSTGRES_DB" ;
 			EOSQL
 			echo
@@ -55,18 +76,31 @@ if [ "$1" = 'postgres' ]; then
 			op='CREATE'
 		fi
 
-		gosu postgres postgres --single -jE <<-EOSQL
+		psql --username postgres <<-EOSQL
 			$op USER "$POSTGRES_USER" WITH SUPERUSER $pass ;
 		EOSQL
 		echo
 
-		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA"/pg_hba.conf
+		echo
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh)  echo "$0: running $f"; . "$f" ;;
+				*.sql) echo "$0: running $f"; psql --username postgres --dbname "$POSTGRES_DB" < "$f" && echo ;;
+				*)     echo "$0: ignoring $f" ;;
+			esac
+			echo
+		done
 
-		if [ -d /docker-entrypoint-initdb.d ]; then
-			for f in /docker-entrypoint-initdb.d/*.sh; do
-				[ -f "$f" ] && . "$f"
-			done
+		if ! kill -s TERM "$pid" || ! wait "$pid"; then
+			echo >&2 'PostgreSQL init process failed'
+			exit 1
 		fi
+
+		set_listen_addresses '*'
+
+		echo
+		echo 'PostgreSQL init process complete; ready for start up.'
+		echo
 	fi
 
 	exec gosu postgres "$@"


### PR DESCRIPTION
`postgres --single` already has a lot of quirks, but is also discouraged for use by upstream (although why that fact isn't included prominently in the documentation for single-user mode, I have no idea -- it seems like an important bit to point out).

This mimics the server startup logic in https://github.com/docker-library/mysql/pull/53 to give us "proper" PostgreSQL server access, while also setting `listen_addresses` to the empty string to prevent remote connections during our initialization process.