### PR TITLE
more sane way of starting and stopping postgres server using pg_ctl

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,8 +7,8 @@ set_listen_addresses() {
 }
 
 if [ "$1" = 'postgres' ]; then
-	mkdir -p "${PGDATA}"
-	chown -R postgres "${PGDATA}"
+	mkdir -p "$PGDATA"
+	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql
 	chown -R postgres /run/postgresql
@@ -45,10 +45,10 @@ if [ "$1" = 'postgres' ]; then
 		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 		# internal start of server in order to allow set-up using psql-client		
-		gosu postgres pg_ctl -D ${PGDATA} \
+		gosu postgres pg_ctl -D "$PGDATA" \
 		     -o "-c listen_addresses=''" \
-		     -w start # does not listen on TCP/IP and wait
-				# until start finished
+		     -w start # does not listen on TCP/IP and waits
+			      # until start finishes
 
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
@@ -81,7 +81,7 @@ if [ "$1" = 'postgres' ]; then
 			echo
 		done
 
-		gosu postgres pg_ctl -D ${PGDATA} -m fast -w stop
+		gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop
 		set_listen_addresses '*'
 
 		echo

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,8 +7,8 @@ set_listen_addresses() {
 }
 
 if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
+	mkdir -p "${PGDATA}"
+	chown -R postgres "${PGDATA}"
 
 	chmod g+s /run/postgresql
 	chown -R postgres /run/postgresql
@@ -44,21 +44,11 @@ if [ "$1" = 'postgres' ]; then
 
 		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
-		set_listen_addresses '' # we're going to start up postgres, but it's not ready for use yet (this is initialization), so don't listen to the outside world yet
-
-		gosu postgres "$@" &
-		pid="$!"
-		for i in {30..0}; do
-			if echo 'SELECT 1' | psql --username postgres &> /dev/null; then
-				break
-			fi
-			echo 'PostgreSQL init process in progress...'
-			sleep 1
-		done
-		if [ "$i" = 0 ]; then
-			echo >&2 'PostgreSQL init process failed'
-			exit 1
-		fi
+		# internal start of server in order to allow set-up using psql-client		
+		gosu postgres pg_ctl -D ${PGDATA} \
+		     -o "-c listen_addresses=''" \
+		     -w start # does not listen on TCP/IP and wait
+				# until start finished
 
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
@@ -91,11 +81,7 @@ if [ "$1" = 'postgres' ]; then
 			echo
 		done
 
-		if ! kill -s TERM "$pid" || ! wait "$pid"; then
-			echo >&2 'PostgreSQL init process failed'
-			exit 1
-		fi
-
+		gosu postgres pg_ctl -D ${PGDATA} -m fast -w stop
 		set_listen_addresses '*'
 
 		echo


### PR DESCRIPTION
as recommended per postgresql docs and implemented according to http://stackoverflow.com/questions/28244869/creating-a-table-in-single-user-mode-in-postgres

The -w option of pg_ctl waits until server is started or stopped. This avoids the 30 second countdown and repeatedly querying database.