### PR TITLE
Export POSTGRES_USER and POSTGRES_DB vars in entrypoint

### DIFF
--- a/9.0/docker-entrypoint.sh
+++ b/9.0/docker-entrypoint.sh
@@ -52,6 +52,7 @@ if [ "$1" = 'postgres' ]; then
 
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
+		export POSTGRES_USER POSTGRES_DB
 
 		if [ "$POSTGRES_DB" != 'postgres' ]; then
 			psql --username postgres <<-EOSQL

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -52,6 +52,7 @@ if [ "$1" = 'postgres' ]; then
 
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
+		export POSTGRES_USER POSTGRES_DB
 
 		if [ "$POSTGRES_DB" != 'postgres' ]; then
 			psql --username postgres <<-EOSQL

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -52,6 +52,7 @@ if [ "$1" = 'postgres' ]; then
 
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
+		export POSTGRES_USER POSTGRES_DB
 
 		if [ "$POSTGRES_DB" != 'postgres' ]; then
 			psql --username postgres <<-EOSQL

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -52,6 +52,7 @@ if [ "$1" = 'postgres' ]; then
 
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
+		export POSTGRES_USER POSTGRES_DB
 
 		if [ "$POSTGRES_DB" != 'postgres' ]; then
 			psql --username postgres <<-EOSQL

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -52,6 +52,7 @@ if [ "$1" = 'postgres' ]; then
 
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
+		export POSTGRES_USER POSTGRES_DB
 
 		if [ "$POSTGRES_DB" != 'postgres' ]; then
 			psql --username postgres <<-EOSQL

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -52,6 +52,7 @@ if [ "$1" = 'postgres' ]; then
 
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
+		export POSTGRES_USER POSTGRES_DB
 
 		if [ "$POSTGRES_DB" != 'postgres' ]; then
 			psql --username postgres <<-EOSQL

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -52,6 +52,7 @@ if [ "$1" = 'postgres' ]; then
 
 		: ${POSTGRES_USER:=postgres}
 		: ${POSTGRES_DB:=$POSTGRES_USER}
+		export POSTGRES_USER POSTGRES_DB
 
 		if [ "$POSTGRES_DB" != 'postgres' ]; then
 			psql --username postgres <<-EOSQL


### PR DESCRIPTION
As it now stands the `$POSTGRES_USER` and `$POSTGRES_DB` variables aren't visible in `/docker-entrypoint-initdb.d/*.sh` scripts unless they have been set explicitly with `-e` in the `docker run` command or with `ENV` in a derived `Dockerfile`.

This change allows those variables to be seen in the `*.sh` scripts. Without this change, any `*.sh` scripts that want to follow the same conventions as the `postgres` base image need to duplicate this code:

```bash
: ${POSTGRES_USER:=postgres}
: ${POSTGRES_DB:=$POSTGRES_USER}
```

I ran into this while trying to implement https://github.com/appropriate/docker-postgis/issues/4 (*Enable PostGIS extensions on default database*).