### PR TITLE
[fix] escaping '*' to '\*'  for listen addresses replacement

### DIFF
--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -83,7 +83,7 @@ if [ "$1" = 'postgres' ]; then
 		done
 
 		gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop
-		set_listen_addresses '*'
+		set_listen_addresses '\*'
 
 		echo
 		echo 'PostgreSQL init process complete; ready for start up.'


### PR DESCRIPTION
'*' is making  listen_addresses ='  ' instead of  listen_addresses = '*' in ubuntu. Escaping it makes more compatible.