### PR TITLE
Explicitly set uid/gid for postgres/postgres

### DIFF
--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -1,8 +1,8 @@
 # vim:set ft=dockerfile:
 FROM debian:jessie
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r postgres && useradd -r -g postgres postgres
+# explicitly set user/group IDs
+RUN groupadd -r postgres --gid=999 && useradd -r -g postgres --uid=999 postgres
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4

--- a/9.1/Dockerfile
+++ b/9.1/Dockerfile
@@ -1,8 +1,8 @@
 # vim:set ft=dockerfile:
 FROM debian:jessie
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r postgres && useradd -r -g postgres postgres
+# explicitly set user/group IDs
+RUN groupadd -r postgres --gid=999 && useradd -r -g postgres --uid=999 postgres
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4

--- a/9.2/Dockerfile
+++ b/9.2/Dockerfile
@@ -1,8 +1,8 @@
 # vim:set ft=dockerfile:
 FROM debian:jessie
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r postgres && useradd -r -g postgres postgres
+# explicitly set user/group IDs
+RUN groupadd -r postgres --gid=999 && useradd -r -g postgres --uid=999 postgres
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4

--- a/9.3/Dockerfile
+++ b/9.3/Dockerfile
@@ -1,8 +1,8 @@
 # vim:set ft=dockerfile:
 FROM debian:jessie
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r postgres && useradd -r -g postgres postgres
+# explicitly set user/group IDs
+RUN groupadd -r postgres --gid=999 && useradd -r -g postgres --uid=999 postgres
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4

--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -1,8 +1,8 @@
 # vim:set ft=dockerfile:
 FROM debian:jessie
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r postgres && useradd -r -g postgres postgres
+# explicitly set user/group IDs
+RUN groupadd -r postgres --gid=999 && useradd -r -g postgres --uid=999 postgres
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -1,8 +1,8 @@
 # vim:set ft=dockerfile:
 FROM debian:jessie
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r postgres && useradd -r -g postgres postgres
+# explicitly set user/group IDs
+RUN groupadd -r postgres --gid=999 && useradd -r -g postgres --uid=999 postgres
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4


### PR DESCRIPTION
The values 999:999 are identical to the current user/group id assigned
in the containers (tested in postgres:9.4, but should be identical for
all versions), but this guarantees that those values will remain the
same even if the `groupadd`/`useradd` commands were moved elsewhere in the
Dockerfile, or a new version of `debian:jessie` image was pushed.

# Testing
```
core@test-1 ~ $ rm -rf pg/
core@test-1 ~ $ docker run -v $(pwd):/origin --rm -it --user=root postgres:9.4 bash -c 'mkdir /origin/pg && chown -R postgres:postgres /origin/pg'
core@test-1 ~ $ ls -hsal pg/
total 8.0K
4.0K drwxr-xr-x 2  999  999 4.0K Sep 22 12:59 .
4.0K drwxr-xr-x 5 core core 4.0K Sep 22 12:59 ..
```

```
core@test-1 ~ $ docker run -v $(pwd):/origin --rm -it debian:jessie bash -c 'groupadd -r postgres --gid=999 && useradd -r -g postgres --uid=999 postgres && mkdir /origin/pg && chown -R postgres:postgres /origin/pg'
core@test-1 ~ $ ls -hsal pg/
total 8.0K
4.0K drwxr-xr-x 2  999  999 4.0K Sep 22 12:57 .
4.0K drwxr-xr-x 5 core core 4.0K Sep 22 12:59 ..
```