### PR TITLE
Set PGDATA permissions to 700

### DIFF
--- a/9.0/docker-entrypoint.sh
+++ b/9.0/docker-entrypoint.sh
@@ -8,6 +8,7 @@ set_listen_addresses() {
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
+	chmod -R 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql

--- a/9.0/docker-entrypoint.sh
+++ b/9.0/docker-entrypoint.sh
@@ -8,7 +8,7 @@ set_listen_addresses() {
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
-	chmod -R 700 "$PGDATA"
+	chmod 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -8,6 +8,7 @@ set_listen_addresses() {
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
+	chmod -R 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -8,7 +8,7 @@ set_listen_addresses() {
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
-	chmod -R 700 "$PGDATA"
+	chmod 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -8,6 +8,7 @@ set_listen_addresses() {
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
+	chmod -R 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -8,7 +8,7 @@ set_listen_addresses() {
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
-	chmod -R 700 "$PGDATA"
+	chmod 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -8,6 +8,7 @@ set_listen_addresses() {
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
+	chmod -R 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -8,7 +8,7 @@ set_listen_addresses() {
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
-	chmod -R 700 "$PGDATA"
+	chmod 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -8,6 +8,7 @@ set_listen_addresses() {
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
+	chmod -R 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -8,7 +8,7 @@ set_listen_addresses() {
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
-	chmod -R 700 "$PGDATA"
+	chmod 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -8,6 +8,7 @@ set_listen_addresses() {
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
+	chmod -R 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -8,7 +8,7 @@ set_listen_addresses() {
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
-	chmod -R 700 "$PGDATA"
+	chmod 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,6 +8,7 @@ set_listen_addresses() {
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
+	chmod -R 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,7 @@ set_listen_addresses() {
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
-	chmod -R 700 "$PGDATA"
+	chmod 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
 	chmod g+s /run/postgresql


### PR DESCRIPTION
When mounting a volume to PGDATA, it may not have permissions set to 700 which causes postgres to fail with:
```
FATAL:  data directory "/var/lib/postgresql/data" has group or world access
Permissions should be u=rwx (0700).
```

To fix this, we can explicitly set it to 700 like we do with the owner.