### PR TITLE
Fixes #105: Update configuration to allow additional settings to be loaded

### DIFF
--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -17,6 +17,7 @@ if [ "$1" = 'postgres' ]; then
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
+		{ echo; echo "include_if_exists = '/etc/postgres/postgresql.conf'"; } >> "$PGDATA/postgresql.conf"
 
 		# check password first so we can output the warning before postgres
 		# messes it up

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -17,6 +17,7 @@ if [ "$1" = 'postgres' ]; then
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
+		sed -i "s|^#include_if_exists = 'exists.conf'|include_if_exists = '/etc/postgres/postgresql.conf'|" "$PGDATA/postgresql.conf"
 
 		# check password first so we can output the warning before postgres
 		# messes it up

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -17,6 +17,7 @@ if [ "$1" = 'postgres' ]; then
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
+		sed -i "s|^#include_if_exists = 'exists.conf'|include_if_exists = '/etc/postgres/postgresql.conf'|" "$PGDATA/postgresql.conf"
 
 		# check password first so we can output the warning before postgres
 		# messes it up

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -17,6 +17,7 @@ if [ "$1" = 'postgres' ]; then
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
 		gosu postgres initdb
+		sed -i "s|^#include_if_exists = 'exists.conf'|include_if_exists = '/etc/postgres/postgresql.conf'|" "$PGDATA/postgresql.conf"
 
 		# check password first so we can output the warning before postgres
 		# messes it up


### PR DESCRIPTION
This allows additional settings to be loaded from `/etc/postgres/postgresql.conf` as part of the docker command which launches any container based on 9.5, 9.4, 9.3 or 9.2. This file is optional.

PostgreSQL version 9.1 and 9.0 do not support `include_if_exists` so they have not been updated. It may be possible to add this feature to them by providing a blank file which can be replaced.

I have tested that the databases created by these docker containers launch, perform simple queries, and have settings which can be updated by loading files.

I was able to load a change with the following command:

`docker run docker run [OPTIONS] -v [FILE]:/etc/postgres/postgresql.conf [IMAGE DETAILS]`

I tested it by increasing the work_mem setting.