### PR TITLE
Set startups scripts folder as a volume

### DIFF
--- a/9.1/Dockerfile
+++ b/9.1/Dockerfile
@@ -53,6 +53,7 @@ VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /
 
+VOLUME /docker-entrypoint-initdb.d
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 5432

--- a/9.2/Dockerfile
+++ b/9.2/Dockerfile
@@ -53,6 +53,7 @@ VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /
 
+VOLUME /docker-entrypoint-initdb.d
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 5432

--- a/9.3/Dockerfile
+++ b/9.3/Dockerfile
@@ -53,6 +53,7 @@ VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /
 
+VOLUME /docker-entrypoint-initdb.d
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 5432

--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -53,6 +53,7 @@ VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /
 
+VOLUME /docker-entrypoint-initdb.d
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 5432

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -53,6 +53,7 @@ VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /
 
+VOLUME /docker-entrypoint-initdb.d
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 5432


### PR DESCRIPTION
This PR avoid creating custom postgres docker images with a single line to add the volume for `docker-entrypoint-initdb.d` like:

```
FROM postgres:9.5
VOLUME /docker-entrypoint-initdb.d
```

This mean we can mount the volume using docker cli or **docker-compose** _yml_ files using the default docker image from registry.