### PR TITLE
Listen on "local" interfaces during init

### DIFF
--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -45,9 +45,9 @@ if [ "$1" = 'postgres' ]; then
 		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 		# internal start of server in order to allow set-up using psql-client		
-		# does not listen on TCP/IP and waits until start finishes
+		# does not listen on external TCP/IP and waits until start finishes
 		gosu postgres pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
+			-o "-c listen_addresses='localhost'" \
 			-w start
 
 		: ${POSTGRES_USER:=postgres}

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -45,9 +45,9 @@ if [ "$1" = 'postgres' ]; then
 		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 		# internal start of server in order to allow set-up using psql-client		
-		# does not listen on TCP/IP and waits until start finishes
+		# does not listen on external TCP/IP and waits until start finishes
 		gosu postgres pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
+			-o "-c listen_addresses='localhost'" \
 			-w start
 
 		: ${POSTGRES_USER:=postgres}

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -45,9 +45,9 @@ if [ "$1" = 'postgres' ]; then
 		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 		# internal start of server in order to allow set-up using psql-client		
-		# does not listen on TCP/IP and waits until start finishes
+		# does not listen on external TCP/IP and waits until start finishes
 		gosu postgres pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
+			-o "-c listen_addresses='localhost'" \
 			-w start
 
 		: ${POSTGRES_USER:=postgres}

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -45,9 +45,9 @@ if [ "$1" = 'postgres' ]; then
 		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 		# internal start of server in order to allow set-up using psql-client		
-		# does not listen on TCP/IP and waits until start finishes
+		# does not listen on external TCP/IP and waits until start finishes
 		gosu postgres pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
+			-o "-c listen_addresses='localhost'" \
 			-w start
 
 		: ${POSTGRES_USER:=postgres}

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -45,9 +45,9 @@ if [ "$1" = 'postgres' ]; then
 		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 		# internal start of server in order to allow set-up using psql-client		
-		# does not listen on TCP/IP and waits until start finishes
+		# does not listen on external TCP/IP and waits until start finishes
 		gosu postgres pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
+			-o "-c listen_addresses='localhost'" \
 			-w start
 
 		: ${POSTGRES_USER:=postgres}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -45,9 +45,9 @@ if [ "$1" = 'postgres' ]; then
 		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 		# internal start of server in order to allow set-up using psql-client		
-		# does not listen on TCP/IP and waits until start finishes
+		# does not listen on external TCP/IP and waits until start finishes
 		gosu postgres pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
+			-o "-c listen_addresses='localhost'" \
 			-w start
 
 		: ${POSTGRES_USER:=postgres}


### PR DESCRIPTION
Fixes #129

http://www.postgresql.org/docs/9.1/static/runtime-config-connection.html

> The default value is localhost, which allows only local TCP/IP "loopback" connections to be made.

This allows for crappy broken drivers that don't support Unix sockets to be usable during initdb.