### PR TITLE
Reset directory to /docker-entrypoint-initdb.d for each initdb script

### DIFF
--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -76,6 +76,7 @@ if [ "$1" = 'postgres' ]; then
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
 		echo
+		cd /docker-entrypoint-initdb.d
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in
 				*.sh)     echo "$0: running $f"; . "$f" ;;
@@ -84,6 +85,7 @@ if [ "$1" = 'postgres' ]; then
 				*)        echo "$0: ignoring $f" ;;
 			esac
 			echo
+			cd /docker-entrypoint-initdb.d
 		done
 
 		gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -76,6 +76,7 @@ if [ "$1" = 'postgres' ]; then
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
 		echo
+		cd /docker-entrypoint-initdb.d
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in
 				*.sh)     echo "$0: running $f"; . "$f" ;;
@@ -84,6 +85,7 @@ if [ "$1" = 'postgres' ]; then
 				*)        echo "$0: ignoring $f" ;;
 			esac
 			echo
+			cd /docker-entrypoint-initdb.d
 		done
 
 		gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -76,6 +76,7 @@ if [ "$1" = 'postgres' ]; then
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
 		echo
+		cd /docker-entrypoint-initdb.d
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in
 				*.sh)     echo "$0: running $f"; . "$f" ;;
@@ -84,6 +85,7 @@ if [ "$1" = 'postgres' ]; then
 				*)        echo "$0: ignoring $f" ;;
 			esac
 			echo
+			cd /docker-entrypoint-initdb.d
 		done
 
 		gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -76,6 +76,7 @@ if [ "$1" = 'postgres' ]; then
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
 		echo
+		cd /docker-entrypoint-initdb.d
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in
 				*.sh)     echo "$0: running $f"; . "$f" ;;
@@ -84,6 +85,7 @@ if [ "$1" = 'postgres' ]; then
 				*)        echo "$0: ignoring $f" ;;
 			esac
 			echo
+			cd /docker-entrypoint-initdb.d
 		done
 
 		gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -76,6 +76,7 @@ if [ "$1" = 'postgres' ]; then
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
 		echo
+		cd /docker-entrypoint-initdb.d
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in
 				*.sh)     echo "$0: running $f"; . "$f" ;;
@@ -84,6 +85,7 @@ if [ "$1" = 'postgres' ]; then
 				*)        echo "$0: ignoring $f" ;;
 			esac
 			echo
+			cd /docker-entrypoint-initdb.d
 		done
 
 		gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -76,6 +76,7 @@ if [ "$1" = 'postgres' ]; then
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
 		echo
+		cd /docker-entrypoint-initdb.d
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in
 				*.sh)     echo "$0: running $f"; . "$f" ;;
@@ -84,6 +85,7 @@ if [ "$1" = 'postgres' ]; then
 				*)        echo "$0: ignoring $f" ;;
 			esac
 			echo
+			cd /docker-entrypoint-initdb.d
 		done
 
 		gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop


### PR DESCRIPTION
Since we source the scripts in initdb.d, any `cd`s will affect other scripts. They could explicitely `cd` back to `/docker-entrypoint-initdb.d`, but I think most would expect to already be there.

Alternatively, if there's not a use case for sourcing the scripts, we could run scripts instead. Not sure which (or either) is more fitting behavior.