### PR TITLE
Enable SSL connection

### DIFF
--- a/9.1/Dockerfile
+++ b/9.1/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* 
 	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+# auto generate a self-signed certificate in /etc/ssl/certs/ssl-cert-snakeoil.pem
+RUN apt-get update && apt-get install -y ssl-cert && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /docker-entrypoint-initdb.d
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -46,8 +46,8 @@ if [ "$1" = 'postgres' ]; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/server.crt"
-			chown -R postgres "$PGDATA/server.crt"
-			chown -R postgres "$PGDATA/server.key"
+			chown postgres "$PGDATA/server.crt"
+			chown postgres "$PGDATA/server.key"
 			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [[ ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
+		if [[ ! -z "$POSTGRES_ENABLE_SSL" || ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [[ ! -z "$POSTGRES_ENABLE_SSL" || ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
+		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [ "$POSTGRES_ENABLE_SSL" ]; then
+		if [[ ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -45,14 +45,12 @@ if [ "$1" = 'postgres' ]; then
 		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
-			mkdir -p "$PGDATA/ssl"
-			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/ssl/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/ssl/server.crt"
-			chmod og-rwx "$PGDATA/ssl/server.key"
-			chown -R postgres "$PGDATA/ssl"
+			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/server.crt"
+			chown -R postgres "$PGDATA/server.crt"
+			chown -R postgres "$PGDATA/server.key"
+			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
-			sed -i "s|#\?ssl_cert_file \?=.*|ssl_cert_file = '$PGDATA/ssl/server.crt'|g" "$PGDATA/postgresql.conf"
-			sed -i "s|#\?ssl_key_file \?=.*|ssl_key_file = '$PGDATA/ssl/server.key'|g" "$PGDATA/postgresql.conf"
 		else
 			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 		fi

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -42,9 +42,8 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
+		hostMethod=host
 		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
-			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
-
 			if [ ! -f "/etc/ssl/certs/postgresql.crt" ]; then
 				cat >&2 <<-'EOWARN'
 					****************************************************
@@ -68,9 +67,10 @@ if [ "$1" = 'postgres' ]; then
 			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
-		else
-			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+			hostMethod=hostssl
 		fi
+
+		{ echo; echo "$hostMethod all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -56,6 +56,7 @@ if [ "$1" = 'postgres' ]; then
 					         to mount your own certificate as a volume.
 					****************************************************
 				EOWARN
+				DEBIAN_FRONTEND=noninteractive make-ssl-cert generate-default-snakeoil --force-overwrite
 				cp /etc/ssl/certs/ssl-cert-snakeoil.pem /etc/ssl/certs/postgresql.crt
 				cp /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/private/postgresql.key
 			fi

--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -42,9 +42,22 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+		if [ "$POSTGRES_ENABLE_SSL" ]; then
+			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
-		# internal start of server in order to allow set-up using psql-client		
+			mkdir -p "$PGDATA/ssl"
+			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/ssl/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/ssl/server.crt"
+			chmod og-rwx "$PGDATA/ssl/server.key"
+			chown -R postgres "$PGDATA/ssl"
+
+			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
+			sed -i "s|#\?ssl_cert_file \?=.*|ssl_cert_file = '$PGDATA/ssl/server.crt'|g" "$PGDATA/postgresql.conf"
+			sed -i "s|#\?ssl_key_file \?=.*|ssl_key_file = '$PGDATA/ssl/server.key'|g" "$PGDATA/postgresql.conf"
+		else
+			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+		fi
+
+		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
 		gosu postgres pg_ctl -D "$PGDATA" \
 			-o "-c listen_addresses='localhost'" \

--- a/9.2/Dockerfile
+++ b/9.2/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* 
 	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+# auto generate a self-signed certificate in /etc/ssl/certs/ssl-cert-snakeoil.pem
+RUN apt-get update && apt-get install -y ssl-cert && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /docker-entrypoint-initdb.d
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -46,8 +46,8 @@ if [ "$1" = 'postgres' ]; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/server.crt"
-			chown -R postgres "$PGDATA/server.crt"
-			chown -R postgres "$PGDATA/server.key"
+			chown postgres "$PGDATA/server.crt"
+			chown postgres "$PGDATA/server.key"
 			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [[ ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
+		if [[ ! -z "$POSTGRES_ENABLE_SSL" || ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [[ ! -z "$POSTGRES_ENABLE_SSL" || ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
+		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [ "$POSTGRES_ENABLE_SSL" ]; then
+		if [[ ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -45,14 +45,12 @@ if [ "$1" = 'postgres' ]; then
 		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
-			mkdir -p "$PGDATA/ssl"
-			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/ssl/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/ssl/server.crt"
-			chmod og-rwx "$PGDATA/ssl/server.key"
-			chown -R postgres "$PGDATA/ssl"
+			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/server.crt"
+			chown -R postgres "$PGDATA/server.crt"
+			chown -R postgres "$PGDATA/server.key"
+			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
-			sed -i "s|#\?ssl_cert_file \?=.*|ssl_cert_file = '$PGDATA/ssl/server.crt'|g" "$PGDATA/postgresql.conf"
-			sed -i "s|#\?ssl_key_file \?=.*|ssl_key_file = '$PGDATA/ssl/server.key'|g" "$PGDATA/postgresql.conf"
 		else
 			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 		fi

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -42,9 +42,8 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
+		hostMethod=host
 		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
-			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
-
 			if [ ! -f "/etc/ssl/certs/postgresql.crt" ]; then
 				cat >&2 <<-'EOWARN'
 					****************************************************
@@ -68,9 +67,10 @@ if [ "$1" = 'postgres' ]; then
 			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
-		else
-			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+			hostMethod=hostssl
 		fi
+
+		{ echo; echo "$hostMethod all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -56,6 +56,7 @@ if [ "$1" = 'postgres' ]; then
 					         to mount your own certificate as a volume.
 					****************************************************
 				EOWARN
+				DEBIAN_FRONTEND=noninteractive make-ssl-cert generate-default-snakeoil --force-overwrite
 				cp /etc/ssl/certs/ssl-cert-snakeoil.pem /etc/ssl/certs/postgresql.crt
 				cp /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/private/postgresql.key
 			fi

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -42,9 +42,22 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+		if [ "$POSTGRES_ENABLE_SSL" ]; then
+			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
-		# internal start of server in order to allow set-up using psql-client		
+			mkdir -p "$PGDATA/ssl"
+			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/ssl/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/ssl/server.crt"
+			chmod og-rwx "$PGDATA/ssl/server.key"
+			chown -R postgres "$PGDATA/ssl"
+
+			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
+			sed -i "s|#\?ssl_cert_file \?=.*|ssl_cert_file = '$PGDATA/ssl/server.crt'|g" "$PGDATA/postgresql.conf"
+			sed -i "s|#\?ssl_key_file \?=.*|ssl_key_file = '$PGDATA/ssl/server.key'|g" "$PGDATA/postgresql.conf"
+		else
+			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+		fi
+
+		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
 		gosu postgres pg_ctl -D "$PGDATA" \
 			-o "-c listen_addresses='localhost'" \

--- a/9.3/Dockerfile
+++ b/9.3/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* 
 	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+# auto generate a self-signed certificate in /etc/ssl/certs/ssl-cert-snakeoil.pem
+RUN apt-get update && apt-get install -y ssl-cert && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /docker-entrypoint-initdb.d
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -46,8 +46,8 @@ if [ "$1" = 'postgres' ]; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/server.crt"
-			chown -R postgres "$PGDATA/server.crt"
-			chown -R postgres "$PGDATA/server.key"
+			chown postgres "$PGDATA/server.crt"
+			chown postgres "$PGDATA/server.key"
 			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [[ ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
+		if [[ ! -z "$POSTGRES_ENABLE_SSL" || ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [[ ! -z "$POSTGRES_ENABLE_SSL" || ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
+		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [ "$POSTGRES_ENABLE_SSL" ]; then
+		if [[ ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -45,14 +45,12 @@ if [ "$1" = 'postgres' ]; then
 		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
-			mkdir -p "$PGDATA/ssl"
-			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/ssl/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/ssl/server.crt"
-			chmod og-rwx "$PGDATA/ssl/server.key"
-			chown -R postgres "$PGDATA/ssl"
+			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/server.crt"
+			chown -R postgres "$PGDATA/server.crt"
+			chown -R postgres "$PGDATA/server.key"
+			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
-			sed -i "s|#\?ssl_cert_file \?=.*|ssl_cert_file = '$PGDATA/ssl/server.crt'|g" "$PGDATA/postgresql.conf"
-			sed -i "s|#\?ssl_key_file \?=.*|ssl_key_file = '$PGDATA/ssl/server.key'|g" "$PGDATA/postgresql.conf"
 		else
 			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 		fi

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -42,9 +42,8 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
+		hostMethod=host
 		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
-			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
-
 			if [ ! -f "/etc/ssl/certs/postgresql.crt" ]; then
 				cat >&2 <<-'EOWARN'
 					****************************************************
@@ -68,9 +67,10 @@ if [ "$1" = 'postgres' ]; then
 			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
-		else
-			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+			hostMethod=hostssl
 		fi
+
+		{ echo; echo "$hostMethod all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -56,6 +56,7 @@ if [ "$1" = 'postgres' ]; then
 					         to mount your own certificate as a volume.
 					****************************************************
 				EOWARN
+				DEBIAN_FRONTEND=noninteractive make-ssl-cert generate-default-snakeoil --force-overwrite
 				cp /etc/ssl/certs/ssl-cert-snakeoil.pem /etc/ssl/certs/postgresql.crt
 				cp /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/private/postgresql.key
 			fi

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -42,9 +42,22 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+		if [ "$POSTGRES_ENABLE_SSL" ]; then
+			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
-		# internal start of server in order to allow set-up using psql-client		
+			mkdir -p "$PGDATA/ssl"
+			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/ssl/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/ssl/server.crt"
+			chmod og-rwx "$PGDATA/ssl/server.key"
+			chown -R postgres "$PGDATA/ssl"
+
+			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
+			sed -i "s|#\?ssl_cert_file \?=.*|ssl_cert_file = '$PGDATA/ssl/server.crt'|g" "$PGDATA/postgresql.conf"
+			sed -i "s|#\?ssl_key_file \?=.*|ssl_key_file = '$PGDATA/ssl/server.key'|g" "$PGDATA/postgresql.conf"
+		else
+			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+		fi
+
+		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
 		gosu postgres pg_ctl -D "$PGDATA" \
 			-o "-c listen_addresses='localhost'" \

--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* 
 	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+# auto generate a self-signed certificate in /etc/ssl/certs/ssl-cert-snakeoil.pem
+RUN apt-get update && apt-get install -y ssl-cert && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /docker-entrypoint-initdb.d
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -46,8 +46,8 @@ if [ "$1" = 'postgres' ]; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/server.crt"
-			chown -R postgres "$PGDATA/server.crt"
-			chown -R postgres "$PGDATA/server.key"
+			chown postgres "$PGDATA/server.crt"
+			chown postgres "$PGDATA/server.key"
 			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [[ ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
+		if [[ ! -z "$POSTGRES_ENABLE_SSL" || ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [[ ! -z "$POSTGRES_ENABLE_SSL" || ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
+		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [ "$POSTGRES_ENABLE_SSL" ]; then
+		if [[ ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -45,14 +45,12 @@ if [ "$1" = 'postgres' ]; then
 		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
-			mkdir -p "$PGDATA/ssl"
-			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/ssl/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/ssl/server.crt"
-			chmod og-rwx "$PGDATA/ssl/server.key"
-			chown -R postgres "$PGDATA/ssl"
+			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/server.crt"
+			chown -R postgres "$PGDATA/server.crt"
+			chown -R postgres "$PGDATA/server.key"
+			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
-			sed -i "s|#\?ssl_cert_file \?=.*|ssl_cert_file = '$PGDATA/ssl/server.crt'|g" "$PGDATA/postgresql.conf"
-			sed -i "s|#\?ssl_key_file \?=.*|ssl_key_file = '$PGDATA/ssl/server.key'|g" "$PGDATA/postgresql.conf"
 		else
 			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 		fi

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -42,9 +42,8 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
+		hostMethod=host
 		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
-			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
-
 			if [ ! -f "/etc/ssl/certs/postgresql.crt" ]; then
 				cat >&2 <<-'EOWARN'
 					****************************************************
@@ -68,9 +67,10 @@ if [ "$1" = 'postgres' ]; then
 			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
-		else
-			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+			hostMethod=hostssl
 		fi
+
+		{ echo; echo "$hostMethod all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -56,6 +56,7 @@ if [ "$1" = 'postgres' ]; then
 					         to mount your own certificate as a volume.
 					****************************************************
 				EOWARN
+				DEBIAN_FRONTEND=noninteractive make-ssl-cert generate-default-snakeoil --force-overwrite
 				cp /etc/ssl/certs/ssl-cert-snakeoil.pem /etc/ssl/certs/postgresql.crt
 				cp /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/private/postgresql.key
 			fi

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -42,9 +42,22 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+		if [ "$POSTGRES_ENABLE_SSL" ]; then
+			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
-		# internal start of server in order to allow set-up using psql-client		
+			mkdir -p "$PGDATA/ssl"
+			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/ssl/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/ssl/server.crt"
+			chmod og-rwx "$PGDATA/ssl/server.key"
+			chown -R postgres "$PGDATA/ssl"
+
+			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
+			sed -i "s|#\?ssl_cert_file \?=.*|ssl_cert_file = '$PGDATA/ssl/server.crt'|g" "$PGDATA/postgresql.conf"
+			sed -i "s|#\?ssl_key_file \?=.*|ssl_key_file = '$PGDATA/ssl/server.key'|g" "$PGDATA/postgresql.conf"
+		else
+			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+		fi
+
+		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
 		gosu postgres pg_ctl -D "$PGDATA" \
 			-o "-c listen_addresses='localhost'" \

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* 
 	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+# auto generate a self-signed certificate in /etc/ssl/certs/ssl-cert-snakeoil.pem
+RUN apt-get update && apt-get install -y ssl-cert && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /docker-entrypoint-initdb.d
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -46,8 +46,8 @@ if [ "$1" = 'postgres' ]; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/server.crt"
-			chown -R postgres "$PGDATA/server.crt"
-			chown -R postgres "$PGDATA/server.key"
+			chown postgres "$PGDATA/server.crt"
+			chown postgres "$PGDATA/server.key"
 			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [[ ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
+		if [[ ! -z "$POSTGRES_ENABLE_SSL" || ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [[ ! -z "$POSTGRES_ENABLE_SSL" || ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
+		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [ "$POSTGRES_ENABLE_SSL" ]; then
+		if [[ ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -45,14 +45,12 @@ if [ "$1" = 'postgres' ]; then
 		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
-			mkdir -p "$PGDATA/ssl"
-			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/ssl/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/ssl/server.crt"
-			chmod og-rwx "$PGDATA/ssl/server.key"
-			chown -R postgres "$PGDATA/ssl"
+			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/server.crt"
+			chown -R postgres "$PGDATA/server.crt"
+			chown -R postgres "$PGDATA/server.key"
+			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
-			sed -i "s|#\?ssl_cert_file \?=.*|ssl_cert_file = '$PGDATA/ssl/server.crt'|g" "$PGDATA/postgresql.conf"
-			sed -i "s|#\?ssl_key_file \?=.*|ssl_key_file = '$PGDATA/ssl/server.key'|g" "$PGDATA/postgresql.conf"
 		else
 			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 		fi

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -42,9 +42,8 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
+		hostMethod=host
 		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
-			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
-
 			if [ ! -f "/etc/ssl/certs/postgresql.crt" ]; then
 				cat >&2 <<-'EOWARN'
 					****************************************************
@@ -68,9 +67,10 @@ if [ "$1" = 'postgres' ]; then
 			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
-		else
-			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+			hostMethod=hostssl
 		fi
+
+		{ echo; echo "$hostMethod all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -56,6 +56,7 @@ if [ "$1" = 'postgres' ]; then
 					         to mount your own certificate as a volume.
 					****************************************************
 				EOWARN
+				DEBIAN_FRONTEND=noninteractive make-ssl-cert generate-default-snakeoil --force-overwrite
 				cp /etc/ssl/certs/ssl-cert-snakeoil.pem /etc/ssl/certs/postgresql.crt
 				cp /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/private/postgresql.key
 			fi

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -42,9 +42,22 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+		if [ "$POSTGRES_ENABLE_SSL" ]; then
+			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
-		# internal start of server in order to allow set-up using psql-client		
+			mkdir -p "$PGDATA/ssl"
+			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/ssl/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/ssl/server.crt"
+			chmod og-rwx "$PGDATA/ssl/server.key"
+			chown -R postgres "$PGDATA/ssl"
+
+			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
+			sed -i "s|#\?ssl_cert_file \?=.*|ssl_cert_file = '$PGDATA/ssl/server.crt'|g" "$PGDATA/postgresql.conf"
+			sed -i "s|#\?ssl_key_file \?=.*|ssl_key_file = '$PGDATA/ssl/server.key'|g" "$PGDATA/postgresql.conf"
+		else
+			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+		fi
+
+		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
 		gosu postgres pg_ctl -D "$PGDATA" \
 			-o "-c listen_addresses='localhost'" \

--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* 
 	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+# auto generate a self-signed certificate in /etc/ssl/certs/ssl-cert-snakeoil.pem
+RUN apt-get update && apt-get install -y ssl-cert && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /docker-entrypoint-initdb.d
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -42,9 +42,37 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
+			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
-		# internal start of server in order to allow set-up using psql-client		
+			if [ ! -f "/etc/ssl/certs/postgresql.crt" ]; then
+				cat >&2 <<-'EOWARN'
+					****************************************************
+					WARNING: Using an auto-generated certificate for SSL.
+					         Please consider using your own certificate
+					         in production environments.
+
+					         Use "-v /my/cert.crt:/etc/ssl/certs/postgresql.crt"
+					         and "-v /my/cert.key:/etc/ssl/private/postgresql.key"
+					         to mount your own certificate as a volume.
+					****************************************************
+				EOWARN
+				cp /etc/ssl/certs/ssl-cert-snakeoil.pem /etc/ssl/certs/postgresql.crt
+				cp /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/private/postgresql.key
+			fi
+
+			cp /etc/ssl/certs/postgresql.crt "$PGDATA/server.crt"
+			cp /etc/ssl/private/postgresql.key "$PGDATA/server.key"
+			chown postgres "$PGDATA/server.crt"
+			chown postgres "$PGDATA/server.key"
+			chmod og-rwx "$PGDATA/server.key"
+
+			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
+		else
+			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+		fi
+
+		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
 		gosu postgres pg_ctl -D "$PGDATA" \
 			-o "-c listen_addresses='localhost'" \

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -42,9 +42,8 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
+		hostMethod=host
 		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
-			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
-
 			if [ ! -f "/etc/ssl/certs/postgresql.crt" ]; then
 				cat >&2 <<-'EOWARN'
 					****************************************************
@@ -68,9 +67,10 @@ if [ "$1" = 'postgres' ]; then
 			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
-		else
-			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+			hostMethod=hostssl
 		fi
+
+		{ echo; echo "$hostMethod all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -56,6 +56,7 @@ if [ "$1" = 'postgres' ]; then
 					         to mount your own certificate as a volume.
 					****************************************************
 				EOWARN
+				DEBIAN_FRONTEND=noninteractive make-ssl-cert generate-default-snakeoil --force-overwrite
 				cp /etc/ssl/certs/ssl-cert-snakeoil.pem /etc/ssl/certs/postgresql.crt
 				cp /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/private/postgresql.key
 			fi

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -23,6 +23,9 @@ RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* 
 	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+# auto generate a self-signed certificate in /etc/ssl/certs/ssl-cert-snakeoil.pem
+RUN apt-get update && apt-get install -y ssl-cert && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /docker-entrypoint-initdb.d
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,8 +46,8 @@ if [ "$1" = 'postgres' ]; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/server.crt"
-			chown -R postgres "$PGDATA/server.crt"
-			chown -R postgres "$PGDATA/server.key"
+			chown postgres "$PGDATA/server.crt"
+			chown postgres "$PGDATA/server.key"
 			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [[ ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
+		if [[ ! -z "$POSTGRES_ENABLE_SSL" || ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [[ ! -z "$POSTGRES_ENABLE_SSL" || ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
+		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		if [ "$POSTGRES_ENABLE_SSL" ]; then
+		if [[ ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 			mkdir -p "$PGDATA/ssl"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -45,14 +45,12 @@ if [ "$1" = 'postgres' ]; then
 		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
 			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
-			mkdir -p "$PGDATA/ssl"
-			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/ssl/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/ssl/server.crt"
-			chmod og-rwx "$PGDATA/ssl/server.key"
-			chown -R postgres "$PGDATA/ssl"
+			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/server.crt"
+			chown -R postgres "$PGDATA/server.crt"
+			chown -R postgres "$PGDATA/server.key"
+			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
-			sed -i "s|#\?ssl_cert_file \?=.*|ssl_cert_file = '$PGDATA/ssl/server.crt'|g" "$PGDATA/postgresql.conf"
-			sed -i "s|#\?ssl_key_file \?=.*|ssl_key_file = '$PGDATA/ssl/server.key'|g" "$PGDATA/postgresql.conf"
 		else
 			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 		fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -42,9 +42,22 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+		if [ "$POSTGRES_ENABLE_SSL" ]; then
+			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
-		# internal start of server in order to allow set-up using psql-client		
+			mkdir -p "$PGDATA/ssl"
+			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/ssl/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/ssl/server.crt"
+			chmod og-rwx "$PGDATA/ssl/server.key"
+			chown -R postgres "$PGDATA/ssl"
+
+			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
+			sed -i "s|#\?ssl_cert_file \?=.*|ssl_cert_file = '$PGDATA/ssl/server.crt'|g" "$PGDATA/postgresql.conf"
+			sed -i "s|#\?ssl_key_file \?=.*|ssl_key_file = '$PGDATA/ssl/server.key'|g" "$PGDATA/postgresql.conf"
+		else
+			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+		fi
+
+		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
 		gosu postgres pg_ctl -D "$PGDATA" \
 			-o "-c listen_addresses='localhost'" \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -42,18 +42,36 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
+		hostMethod=host
 		if [[ ! -z "$POSTGRES_ENABLE_SSL" && ! $POSTGRES_ENABLE_SSL =~ ^([nN][oO]|[nN]|[fF][aA][lL][sS][eE]|[fF]|0)$ ]] ; then
-			{ echo; echo "hostssl all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+			if [ ! -f "/etc/ssl/certs/postgresql.crt" ]; then
+				cat >&2 <<-'EOWARN'
+					****************************************************
+					WARNING: Using an auto-generated certificate for SSL.
+					         Please consider using your own certificate
+					         in production environments.
 
-			openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 -keyout "$PGDATA/server.key" -subj "/CN=PostgreSQL" -out "$PGDATA/server.crt"
+					         Use "-v /my/cert.crt:/etc/ssl/certs/postgresql.crt"
+					         and "-v /my/cert.key:/etc/ssl/private/postgresql.key"
+					         to mount your own certificate as a volume.
+					****************************************************
+				EOWARN
+				DEBIAN_FRONTEND=noninteractive make-ssl-cert generate-default-snakeoil --force-overwrite
+				cp /etc/ssl/certs/ssl-cert-snakeoil.pem /etc/ssl/certs/postgresql.crt
+				cp /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/private/postgresql.key
+			fi
+
+			cp /etc/ssl/certs/postgresql.crt "$PGDATA/server.crt"
+			cp /etc/ssl/private/postgresql.key "$PGDATA/server.key"
 			chown postgres "$PGDATA/server.crt"
 			chown postgres "$PGDATA/server.key"
 			chmod og-rwx "$PGDATA/server.key"
 
 			sed -i "s|#\?ssl \?=.*|ssl = on|g" "$PGDATA/postgresql.conf"
-		else
-			{ echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
+			hostMethod=hostssl
 		fi
+
+		{ echo; echo "$hostMethod all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA/pg_hba.conf"
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes


### PR DESCRIPTION
Hello,

This PR adds a new configuration `$POSTGRES_ENABLE_SSL` which:
- Automatically generates an SSL keypair on init using OpenSSL
- Forces the use of an SSL connection to connect to Postgres

Best