### PR TITLE
mkdir should work on /run instead of /var/run

### DIFF
--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -45,7 +45,7 @@ RUN mv -v /usr/share/postgresql/$PG_MAJOR/postgresql.conf.sample /usr/share/post
 	&& ln -sv ../postgresql.conf.sample /usr/share/postgresql/$PG_MAJOR/ \
 	&& sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/share/postgresql/postgresql.conf.sample
 
-RUN mkdir -p /var/run/postgresql && chown -R postgres /var/run/postgresql
+RUN mkdir -p /run/postgresql && chown -R postgres /run/postgresql
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data


### PR DESCRIPTION
In debian:jessie, /var/run is a symlink to /run.  The docker file creates the postgresql directory under /var/run, but the docker-entrypoint.sh file also tries to make /run/postgresql and chown that as well.