### PR TITLE
Add support for reading password from a file

### DIFF
--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -22,6 +22,9 @@ if [ "$1" = 'postgres' ]; then
 		if [ "$POSTGRES_PASSWORD" ]; then
 			pass="PASSWORD '$POSTGRES_PASSWORD'"
 			authMethod=md5
+		elif [ "$POSTGRES_PASSWORD_FILE" ]; then
+			pass="PASSWORD '`cat $POSTGRES_PASSWORD_FILE`'"
+			authMethod=md5
 		else
 			# The - option suppresses leading tabs but *not* spaces. :)
 			cat >&2 <<-'EOWARN'
@@ -33,8 +36,9 @@ if [ "$1" = 'postgres' ]; then
 				         effectively any other container on the same
 				         system.
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
+				         Use "-e POSTGRES_PASSWORD=password" or
+				         "-e POSTGRES_PASSWORD_FILE=/my-password" to
+				         set it in "docker run"
 				****************************************************
 			EOWARN
 

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -22,6 +22,9 @@ if [ "$1" = 'postgres' ]; then
 		if [ "$POSTGRES_PASSWORD" ]; then
 			pass="PASSWORD '$POSTGRES_PASSWORD'"
 			authMethod=md5
+		elif [ "$POSTGRES_PASSWORD_FILE" ]; then
+			pass="PASSWORD '`cat $POSTGRES_PASSWORD_FILE`'"
+			authMethod=md5
 		else
 			# The - option suppresses leading tabs but *not* spaces. :)
 			cat >&2 <<-'EOWARN'
@@ -33,8 +36,9 @@ if [ "$1" = 'postgres' ]; then
 				         effectively any other container on the same
 				         system.
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
+				         Use "-e POSTGRES_PASSWORD=password" or
+				         "-e POSTGRES_PASSWORD_FILE=/my-password" to
+				         set it in "docker run"
 				****************************************************
 			EOWARN
 

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -22,6 +22,9 @@ if [ "$1" = 'postgres' ]; then
 		if [ "$POSTGRES_PASSWORD" ]; then
 			pass="PASSWORD '$POSTGRES_PASSWORD'"
 			authMethod=md5
+		elif [ "$POSTGRES_PASSWORD_FILE" ]; then
+			pass="PASSWORD '`cat $POSTGRES_PASSWORD_FILE`'"
+			authMethod=md5
 		else
 			# The - option suppresses leading tabs but *not* spaces. :)
 			cat >&2 <<-'EOWARN'
@@ -33,8 +36,9 @@ if [ "$1" = 'postgres' ]; then
 				         effectively any other container on the same
 				         system.
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
+				         Use "-e POSTGRES_PASSWORD=password" or
+				         "-e POSTGRES_PASSWORD_FILE=/my-password" to
+				         set it in "docker run"
 				****************************************************
 			EOWARN
 

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -22,6 +22,9 @@ if [ "$1" = 'postgres' ]; then
 		if [ "$POSTGRES_PASSWORD" ]; then
 			pass="PASSWORD '$POSTGRES_PASSWORD'"
 			authMethod=md5
+		elif [ "$POSTGRES_PASSWORD_FILE" ]; then
+			pass="PASSWORD '`cat $POSTGRES_PASSWORD_FILE`'"
+			authMethod=md5
 		else
 			# The - option suppresses leading tabs but *not* spaces. :)
 			cat >&2 <<-'EOWARN'
@@ -33,8 +36,9 @@ if [ "$1" = 'postgres' ]; then
 				         effectively any other container on the same
 				         system.
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
+				         Use "-e POSTGRES_PASSWORD=password" or
+				         "-e POSTGRES_PASSWORD_FILE=/my-password" to
+				         set it in "docker run"
 				****************************************************
 			EOWARN
 

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -22,6 +22,9 @@ if [ "$1" = 'postgres' ]; then
 		if [ "$POSTGRES_PASSWORD" ]; then
 			pass="PASSWORD '$POSTGRES_PASSWORD'"
 			authMethod=md5
+		elif [ "$POSTGRES_PASSWORD_FILE" ]; then
+			pass="PASSWORD '`cat $POSTGRES_PASSWORD_FILE`'"
+			authMethod=md5
 		else
 			# The - option suppresses leading tabs but *not* spaces. :)
 			cat >&2 <<-'EOWARN'
@@ -33,8 +36,9 @@ if [ "$1" = 'postgres' ]; then
 				         effectively any other container on the same
 				         system.
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
+				         Use "-e POSTGRES_PASSWORD=password" or
+				         "-e POSTGRES_PASSWORD_FILE=/my-password" to
+				         set it in "docker run"
 				****************************************************
 			EOWARN
 

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -22,6 +22,9 @@ if [ "$1" = 'postgres' ]; then
 		if [ "$POSTGRES_PASSWORD" ]; then
 			pass="PASSWORD '$POSTGRES_PASSWORD'"
 			authMethod=md5
+		elif [ "$POSTGRES_PASSWORD_FILE" ]; then
+			pass="PASSWORD '`cat $POSTGRES_PASSWORD_FILE`'"
+			authMethod=md5
 		else
 			# The - option suppresses leading tabs but *not* spaces. :)
 			cat >&2 <<-'EOWARN'
@@ -33,8 +36,9 @@ if [ "$1" = 'postgres' ]; then
 				         effectively any other container on the same
 				         system.
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
+				         Use "-e POSTGRES_PASSWORD=password" or
+				         "-e POSTGRES_PASSWORD_FILE=/my-password" to
+				         set it in "docker run"
 				****************************************************
 			EOWARN
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,6 +22,9 @@ if [ "$1" = 'postgres' ]; then
 		if [ "$POSTGRES_PASSWORD" ]; then
 			pass="PASSWORD '$POSTGRES_PASSWORD'"
 			authMethod=md5
+		elif [ "$POSTGRES_PASSWORD_FILE" ]; then
+			pass="PASSWORD '`cat $POSTGRES_PASSWORD_FILE`'"
+			authMethod=md5
 		else
 			# The - option suppresses leading tabs but *not* spaces. :)
 			cat >&2 <<-'EOWARN'
@@ -33,8 +36,9 @@ if [ "$1" = 'postgres' ]; then
 				         effectively any other container on the same
 				         system.
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
+				         Use "-e POSTGRES_PASSWORD=password" or
+				         "-e POSTGRES_PASSWORD_FILE=/my-password" to
+				         set it in "docker run"
 				****************************************************
 			EOWARN
 


### PR DESCRIPTION
Supplying a POSTGRES_PASSWORD_FILE variable, which points to a file on disk within the container, will now be read and used as the value of the password. The original POSTGRES_PASSWORD variable takes precedence over the new POSTGRES_PASSWORD_FILE variable.
