### PR TITLE
Allow run shell script before importing dump

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -76,9 +76,15 @@ if [ "$1" = 'postgres' ]; then
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
 		echo
+		for f in /docker-entrypoint-initdb.d/*.sh; do
+			echo "$0: running $f"; . "$f" ;;
+			echo
+		done
+
+		echo
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in
-				*.sh)     echo "$0: running $f"; . "$f" ;;
+				*.sh)     ;; # do nothing, since we already executed scripts above
 				*.sql)    echo "$0: running $f"; "${psql[@]}" < "$f"; echo ;;
 				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${psql[@]}"; echo ;;
 				*)        echo "$0: ignoring $f" ;;


### PR DESCRIPTION
If shell script downloads some sql dumps, these dump are not being processed. This PR runs shell scripts first, then process the dump.