### PR TITLE
Entrypoint script avoiding non-files

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -77,6 +77,10 @@ if [ "$1" = 'postgres' ]; then
 
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
+			if [ ! -f "$f" ]; then
+		        	echo "$0: ignoring $f (not a file)"; echo
+		        	continue
+		    	fi
 			case "$f" in
 				*.sh)     echo "$0: running $f"; . "$f" ;;
 				*.sql)    echo "$0: running $f"; "${psql[@]}" < "$f"; echo ;;


### PR DESCRIPTION
If a SQL file does not exist in the docker machine to be mounted, the mount point is created as an empty folder. This pull request prevents the entrypoint script calls psql in vain.
