### PR TITLE
Add "mkdir -p /run/postgresql" to docker-entrypoint.sh.

### DIFF
--- a/9.1/docker-entrypoint.sh
+++ b/9.1/docker-entrypoint.sh
@@ -10,6 +10,7 @@ if [ "$1" = 'postgres' ]; then
 	chmod 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
+	mkdir -p /run/postgresql
 	chmod g+s /run/postgresql
 	chown -R postgres /run/postgresql
 

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -10,6 +10,7 @@ if [ "$1" = 'postgres' ]; then
 	chmod 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
+	mkdir -p /run/postgresql
 	chmod g+s /run/postgresql
 	chown -R postgres /run/postgresql
 

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -10,6 +10,7 @@ if [ "$1" = 'postgres' ]; then
 	chmod 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
+	mkdir -p /run/postgresql
 	chmod g+s /run/postgresql
 	chown -R postgres /run/postgresql
 

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -10,6 +10,7 @@ if [ "$1" = 'postgres' ]; then
 	chmod 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
+	mkdir -p /run/postgresql
 	chmod g+s /run/postgresql
 	chown -R postgres /run/postgresql
 

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -10,6 +10,7 @@ if [ "$1" = 'postgres' ]; then
 	chmod 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
+	mkdir -p /run/postgresql
 	chmod g+s /run/postgresql
 	chown -R postgres /run/postgresql
 

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -10,6 +10,7 @@ if [ "$1" = 'postgres' ]; then
 	chmod 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
+	mkdir -p /run/postgresql
 	chmod g+s /run/postgresql
 	chown -R postgres /run/postgresql
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,7 @@ if [ "$1" = 'postgres' ]; then
 	chmod 700 "$PGDATA"
 	chown -R postgres "$PGDATA"
 
+	mkdir -p /run/postgresql
 	chmod g+s /run/postgresql
 	chown -R postgres /run/postgresql
 


### PR DESCRIPTION
This allows the container to run with a tmpfs /run.

It seems like this is the only change that is needed to run this image read-only with a tmpfs /run and /tmp but I need to test it more.