### PR TITLE
Remove "doc" and "man" from Alpine images for size

### DIFF
--- a/9.2/alpine/Dockerfile
+++ b/9.2/alpine/Dockerfile
@@ -106,6 +106,8 @@ RUN set -ex \
 	&& rm -rf \
 		/usr/src/postgresql \
 		/usr/local/include/* \
+		/usr/local/share/doc \
+		/usr/local/share/man \
 	&& find /usr/local -name '*.a' -delete
 
 # make the sample config easier to munge (and "correct by default")

--- a/9.3/alpine/Dockerfile
+++ b/9.3/alpine/Dockerfile
@@ -106,6 +106,8 @@ RUN set -ex \
 	&& rm -rf \
 		/usr/src/postgresql \
 		/usr/local/include/* \
+		/usr/local/share/doc \
+		/usr/local/share/man \
 	&& find /usr/local -name '*.a' -delete
 
 # make the sample config easier to munge (and "correct by default")

--- a/9.4/alpine/Dockerfile
+++ b/9.4/alpine/Dockerfile
@@ -106,6 +106,8 @@ RUN set -ex \
 	&& rm -rf \
 		/usr/src/postgresql \
 		/usr/local/include/* \
+		/usr/local/share/doc \
+		/usr/local/share/man \
 	&& find /usr/local -name '*.a' -delete
 
 # make the sample config easier to munge (and "correct by default")

--- a/9.5/alpine/Dockerfile
+++ b/9.5/alpine/Dockerfile
@@ -106,6 +106,8 @@ RUN set -ex \
 	&& rm -rf \
 		/usr/src/postgresql \
 		/usr/local/include/* \
+		/usr/local/share/doc \
+		/usr/local/share/man \
 	&& find /usr/local -name '*.a' -delete
 
 # make the sample config easier to munge (and "correct by default")

--- a/9.6/alpine/Dockerfile
+++ b/9.6/alpine/Dockerfile
@@ -106,6 +106,8 @@ RUN set -ex \
 	&& rm -rf \
 		/usr/src/postgresql \
 		/usr/local/include/* \
+		/usr/local/share/doc \
+		/usr/local/share/man \
 	&& find /usr/local -name '*.a' -delete
 
 # make the sample config easier to munge (and "correct by default")

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -106,6 +106,8 @@ RUN set -ex \
 	&& rm -rf \
 		/usr/src/postgresql \
 		/usr/local/include/* \
+		/usr/local/share/doc \
+		/usr/local/share/man \
 	&& find /usr/local -name '*.a' -delete
 
 # make the sample config easier to munge (and "correct by default")


### PR DESCRIPTION
Fixes #241

```
postgres  9.6-alpine-after    83c9edfc60a1        2 minutes ago       32.53 MB
postgres  9.6-alpine-before   56409b6ffc83        9 minutes ago       49.43 MB
```