### PR TITLE
Keep lib sources so the image can be used as a base image for postgis

### DIFF
--- a/9.2/alpine/Dockerfile
+++ b/9.2/alpine/Dockerfile
@@ -105,7 +105,6 @@ RUN set -ex \
 	&& cd / \
 	&& rm -rf \
 		/usr/src/postgresql \
-		/usr/local/include/* \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	&& find /usr/local -name '*.a' -delete

--- a/9.3/alpine/Dockerfile
+++ b/9.3/alpine/Dockerfile
@@ -105,7 +105,6 @@ RUN set -ex \
 	&& cd / \
 	&& rm -rf \
 		/usr/src/postgresql \
-		/usr/local/include/* \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	&& find /usr/local -name '*.a' -delete

--- a/9.4/alpine/Dockerfile
+++ b/9.4/alpine/Dockerfile
@@ -105,7 +105,6 @@ RUN set -ex \
 	&& cd / \
 	&& rm -rf \
 		/usr/src/postgresql \
-		/usr/local/include/* \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	&& find /usr/local -name '*.a' -delete

--- a/9.5/alpine/Dockerfile
+++ b/9.5/alpine/Dockerfile
@@ -105,7 +105,6 @@ RUN set -ex \
 	&& cd / \
 	&& rm -rf \
 		/usr/src/postgresql \
-		/usr/local/include/* \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	&& find /usr/local -name '*.a' -delete

--- a/9.6/alpine/Dockerfile
+++ b/9.6/alpine/Dockerfile
@@ -105,7 +105,6 @@ RUN set -ex \
 	&& cd / \
 	&& rm -rf \
 		/usr/src/postgresql \
-		/usr/local/include/* \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	&& find /usr/local -name '*.a' -delete

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -105,7 +105,6 @@ RUN set -ex \
 	&& cd / \
 	&& rm -rf \
 		/usr/src/postgresql \
-		/usr/local/include/* \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	&& find /usr/local -name '*.a' -delete


### PR DESCRIPTION
Unless there's a way to only install the source headers from the postgres source, it's impossible to use this image as a base image for postgis because they are missing. It only adds 3 MB of data to the image to keep them: 
```
REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
postgres               test                136c6c4d4782        10 minutes ago      35.3 MB
postgres               9.3-alpine          7c9bad9f1e8f        9 days ago          32.2 MB
```