### PR TITLE
Allow arbitrary --user values (mostly)

### DIFF
--- a/9.2/Dockerfile
+++ b/9.2/Dockerfile
@@ -58,7 +58,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgres
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
-RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 700 "$PGDATA"
+RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /

--- a/9.2/alpine/Dockerfile
+++ b/9.2/alpine/Dockerfile
@@ -122,7 +122,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgres
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
-RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 700 "$PGDATA"
+RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /

--- a/9.2/alpine/docker-entrypoint.sh
+++ b/9.2/alpine/docker-entrypoint.sh
@@ -27,7 +27,8 @@ if [ "${1:0:1}" = '-' ]; then
 	set -- postgres "$@"
 fi
 
-if [ "$1" = 'postgres' ]; then
+# allow the container to be started with `--user`
+if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATA"
 	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
@@ -36,11 +37,18 @@ if [ "$1" = 'postgres' ]; then
 	chown -R postgres /var/run/postgresql
 	chmod g+s /var/run/postgresql
 
+	exec su-exec postgres "$BASH_SOURCE" "$@"
+fi
+
+if [ "$1" = 'postgres' ]; then
+	mkdir -p "$PGDATA"
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+
 		file_env 'POSTGRES_INITDB_ARGS'
-		eval "su-exec postgres initdb $POSTGRES_INITDB_ARGS"
+		eval "initdb --username=postgres $POSTGRES_INITDB_ARGS"
 
 		# check password first so we can output the warning before postgres
 		# messes it up
@@ -68,11 +76,12 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		{ echo; echo "host all all all $authMethod"; } | su-exec postgres tee -a "$PGDATA/pg_hba.conf" > /dev/null
+		{ echo; echo "host all all all $authMethod"; } | tee -a "$PGDATA/pg_hba.conf" > /dev/null
 
 		# internal start of server in order to allow set-up using psql-client		
 		# does not listen on external TCP/IP and waits until start finishes
-		su-exec postgres pg_ctl -D "$PGDATA" \
+		PGUSER="${PGUSER:-postgres}" \
+		pg_ctl -D "$PGDATA" \
 			-o "-c listen_addresses='localhost'" \
 			-w start
 
@@ -111,14 +120,13 @@ if [ "$1" = 'postgres' ]; then
 			echo
 		done
 
-		su-exec postgres pg_ctl -D "$PGDATA" -m fast -w stop
+		PGUSER="${PGUSER:-postgres}" \
+		pg_ctl -D "$PGDATA" -m fast -w stop
 
 		echo
 		echo 'PostgreSQL init process complete; ready for start up.'
 		echo
 	fi
-
-	exec su-exec postgres "$@"
 fi
 
 exec "$@"

--- a/9.3/Dockerfile
+++ b/9.3/Dockerfile
@@ -58,7 +58,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgres
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
-RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 700 "$PGDATA"
+RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /

--- a/9.3/alpine/Dockerfile
+++ b/9.3/alpine/Dockerfile
@@ -122,7 +122,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgres
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
-RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 700 "$PGDATA"
+RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /

--- a/9.3/alpine/docker-entrypoint.sh
+++ b/9.3/alpine/docker-entrypoint.sh
@@ -27,7 +27,8 @@ if [ "${1:0:1}" = '-' ]; then
 	set -- postgres "$@"
 fi
 
-if [ "$1" = 'postgres' ]; then
+# allow the container to be started with `--user`
+if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATA"
 	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
@@ -36,11 +37,18 @@ if [ "$1" = 'postgres' ]; then
 	chown -R postgres /var/run/postgresql
 	chmod g+s /var/run/postgresql
 
+	exec su-exec postgres "$BASH_SOURCE" "$@"
+fi
+
+if [ "$1" = 'postgres' ]; then
+	mkdir -p "$PGDATA"
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+
 		file_env 'POSTGRES_INITDB_ARGS'
-		eval "su-exec postgres initdb $POSTGRES_INITDB_ARGS"
+		eval "initdb --username=postgres $POSTGRES_INITDB_ARGS"
 
 		# check password first so we can output the warning before postgres
 		# messes it up
@@ -68,11 +76,12 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		{ echo; echo "host all all all $authMethod"; } | su-exec postgres tee -a "$PGDATA/pg_hba.conf" > /dev/null
+		{ echo; echo "host all all all $authMethod"; } | tee -a "$PGDATA/pg_hba.conf" > /dev/null
 
 		# internal start of server in order to allow set-up using psql-client		
 		# does not listen on external TCP/IP and waits until start finishes
-		su-exec postgres pg_ctl -D "$PGDATA" \
+		PGUSER="${PGUSER:-postgres}" \
+		pg_ctl -D "$PGDATA" \
 			-o "-c listen_addresses='localhost'" \
 			-w start
 
@@ -111,14 +120,13 @@ if [ "$1" = 'postgres' ]; then
 			echo
 		done
 
-		su-exec postgres pg_ctl -D "$PGDATA" -m fast -w stop
+		PGUSER="${PGUSER:-postgres}" \
+		pg_ctl -D "$PGDATA" -m fast -w stop
 
 		echo
 		echo 'PostgreSQL init process complete; ready for start up.'
 		echo
 	fi
-
-	exec su-exec postgres "$@"
 fi
 
 exec "$@"

--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -58,7 +58,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgres
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
-RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 700 "$PGDATA"
+RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /

--- a/9.4/alpine/Dockerfile
+++ b/9.4/alpine/Dockerfile
@@ -122,7 +122,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgres
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
-RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 700 "$PGDATA"
+RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /

--- a/9.4/alpine/docker-entrypoint.sh
+++ b/9.4/alpine/docker-entrypoint.sh
@@ -27,7 +27,8 @@ if [ "${1:0:1}" = '-' ]; then
 	set -- postgres "$@"
 fi
 
-if [ "$1" = 'postgres' ]; then
+# allow the container to be started with `--user`
+if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATA"
 	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
@@ -36,11 +37,18 @@ if [ "$1" = 'postgres' ]; then
 	chown -R postgres /var/run/postgresql
 	chmod g+s /var/run/postgresql
 
+	exec su-exec postgres "$BASH_SOURCE" "$@"
+fi
+
+if [ "$1" = 'postgres' ]; then
+	mkdir -p "$PGDATA"
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+
 		file_env 'POSTGRES_INITDB_ARGS'
-		eval "su-exec postgres initdb $POSTGRES_INITDB_ARGS"
+		eval "initdb --username=postgres $POSTGRES_INITDB_ARGS"
 
 		# check password first so we can output the warning before postgres
 		# messes it up
@@ -68,11 +76,12 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		{ echo; echo "host all all all $authMethod"; } | su-exec postgres tee -a "$PGDATA/pg_hba.conf" > /dev/null
+		{ echo; echo "host all all all $authMethod"; } | tee -a "$PGDATA/pg_hba.conf" > /dev/null
 
 		# internal start of server in order to allow set-up using psql-client		
 		# does not listen on external TCP/IP and waits until start finishes
-		su-exec postgres pg_ctl -D "$PGDATA" \
+		PGUSER="${PGUSER:-postgres}" \
+		pg_ctl -D "$PGDATA" \
 			-o "-c listen_addresses='localhost'" \
 			-w start
 
@@ -111,14 +120,13 @@ if [ "$1" = 'postgres' ]; then
 			echo
 		done
 
-		su-exec postgres pg_ctl -D "$PGDATA" -m fast -w stop
+		PGUSER="${PGUSER:-postgres}" \
+		pg_ctl -D "$PGDATA" -m fast -w stop
 
 		echo
 		echo 'PostgreSQL init process complete; ready for start up.'
 		echo
 	fi
-
-	exec su-exec postgres "$@"
 fi
 
 exec "$@"

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -58,7 +58,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgres
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
-RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 700 "$PGDATA"
+RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /

--- a/9.5/alpine/Dockerfile
+++ b/9.5/alpine/Dockerfile
@@ -122,7 +122,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgres
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
-RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 700 "$PGDATA"
+RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /

--- a/9.5/alpine/docker-entrypoint.sh
+++ b/9.5/alpine/docker-entrypoint.sh
@@ -27,7 +27,8 @@ if [ "${1:0:1}" = '-' ]; then
 	set -- postgres "$@"
 fi
 
-if [ "$1" = 'postgres' ]; then
+# allow the container to be started with `--user`
+if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATA"
 	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
@@ -36,11 +37,18 @@ if [ "$1" = 'postgres' ]; then
 	chown -R postgres /var/run/postgresql
 	chmod g+s /var/run/postgresql
 
+	exec su-exec postgres "$BASH_SOURCE" "$@"
+fi
+
+if [ "$1" = 'postgres' ]; then
+	mkdir -p "$PGDATA"
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+
 		file_env 'POSTGRES_INITDB_ARGS'
-		eval "su-exec postgres initdb $POSTGRES_INITDB_ARGS"
+		eval "initdb --username=postgres $POSTGRES_INITDB_ARGS"
 
 		# check password first so we can output the warning before postgres
 		# messes it up
@@ -68,11 +76,12 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		{ echo; echo "host all all all $authMethod"; } | su-exec postgres tee -a "$PGDATA/pg_hba.conf" > /dev/null
+		{ echo; echo "host all all all $authMethod"; } | tee -a "$PGDATA/pg_hba.conf" > /dev/null
 
 		# internal start of server in order to allow set-up using psql-client		
 		# does not listen on external TCP/IP and waits until start finishes
-		su-exec postgres pg_ctl -D "$PGDATA" \
+		PGUSER="${PGUSER:-postgres}" \
+		pg_ctl -D "$PGDATA" \
 			-o "-c listen_addresses='localhost'" \
 			-w start
 
@@ -111,14 +120,13 @@ if [ "$1" = 'postgres' ]; then
 			echo
 		done
 
-		su-exec postgres pg_ctl -D "$PGDATA" -m fast -w stop
+		PGUSER="${PGUSER:-postgres}" \
+		pg_ctl -D "$PGDATA" -m fast -w stop
 
 		echo
 		echo 'PostgreSQL init process complete; ready for start up.'
 		echo
 	fi
-
-	exec su-exec postgres "$@"
 fi
 
 exec "$@"

--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -58,7 +58,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgres
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
-RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 700 "$PGDATA"
+RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /

--- a/9.6/alpine/Dockerfile
+++ b/9.6/alpine/Dockerfile
@@ -122,7 +122,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgres
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
-RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 700 "$PGDATA"
+RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /

--- a/9.6/alpine/docker-entrypoint.sh
+++ b/9.6/alpine/docker-entrypoint.sh
@@ -27,7 +27,8 @@ if [ "${1:0:1}" = '-' ]; then
 	set -- postgres "$@"
 fi
 
-if [ "$1" = 'postgres' ]; then
+# allow the container to be started with `--user`
+if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATA"
 	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
@@ -36,11 +37,18 @@ if [ "$1" = 'postgres' ]; then
 	chown -R postgres /var/run/postgresql
 	chmod g+s /var/run/postgresql
 
+	exec su-exec postgres "$BASH_SOURCE" "$@"
+fi
+
+if [ "$1" = 'postgres' ]; then
+	mkdir -p "$PGDATA"
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+
 		file_env 'POSTGRES_INITDB_ARGS'
-		eval "su-exec postgres initdb $POSTGRES_INITDB_ARGS"
+		eval "initdb --username=postgres $POSTGRES_INITDB_ARGS"
 
 		# check password first so we can output the warning before postgres
 		# messes it up
@@ -68,11 +76,12 @@ if [ "$1" = 'postgres' ]; then
 			authMethod=trust
 		fi
 
-		{ echo; echo "host all all all $authMethod"; } | su-exec postgres tee -a "$PGDATA/pg_hba.conf" > /dev/null
+		{ echo; echo "host all all all $authMethod"; } | tee -a "$PGDATA/pg_hba.conf" > /dev/null
 
 		# internal start of server in order to allow set-up using psql-client		
 		# does not listen on external TCP/IP and waits until start finishes
-		su-exec postgres pg_ctl -D "$PGDATA" \
+		PGUSER="${PGUSER:-postgres}" \
+		pg_ctl -D "$PGDATA" \
 			-o "-c listen_addresses='localhost'" \
 			-w start
 
@@ -111,14 +120,13 @@ if [ "$1" = 'postgres' ]; then
 			echo
 		done
 
-		su-exec postgres pg_ctl -D "$PGDATA" -m fast -w stop
+		PGUSER="${PGUSER:-postgres}" \
+		pg_ctl -D "$PGDATA" -m fast -w stop
 
 		echo
 		echo 'PostgreSQL init process complete; ready for start up.'
 		echo
 	fi
-
-	exec su-exec postgres "$@"
 fi
 
 exec "$@"

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -122,7 +122,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgres
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
-RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 700 "$PGDATA"
+RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -58,7 +58,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgres
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
-RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 700 "$PGDATA"
+RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /


### PR DESCRIPTION
One special case is that `initdb` _requires_ the current user to exist in `/etc/passwd`, but running PostgreSQL itself does not require that.

As discussed over in https://github.com/docker-library/postgres/pull/93#issuecomment-273877372.

See also docker-library/rabbitmq#60, docker-library/cassandra#48, docker-library/mongo#81, docker-library/redis#48, docker-library/mysql#161, docker-library/mariadb#59, docker-library/percona#21, and https://github.com/docker-library/ghost/pull/54.

Closes #46
Closes #116
Closes #206
Closes #251
Ref #28