### PR TITLE
Add ossp uuid to the alpine 9.2 and 9.3 images

### DIFF
--- a/9.2/alpine/Dockerfile
+++ b/9.2/alpine/Dockerfile
@@ -39,6 +39,7 @@ RUN set -ex \
 	\
 	&& apk add --no-cache --virtual .build-deps \
 		bison \
+		coreutils \
 		flex \
 		gcc \
 #		krb5-dev \
@@ -57,7 +58,9 @@ RUN set -ex \
 		util-linux-dev \
 		zlib-dev \
 	\
-    && wget -O uuid.tar.gz "http://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/uuid-$OSSP_UUID_VERSION.tar.gz" \
+# install OSSP uuid (http://www.ossp.org/pkg/lib/uuid/)
+# see https://github.com/docker-library/postgres/pull/255 for more details
+	&& wget -O uuid.tar.gz "https://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/uuid-$OSSP_UUID_VERSION.tar.gz" \
 	&& echo "$OSSP_UUID_SHA256 *uuid.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/src/ossp-uuid \
 	&& tar \
@@ -66,13 +69,15 @@ RUN set -ex \
 		--directory /usr/src/ossp-uuid \
 		--strip-components 1 \
 	&& rm uuid.tar.gz \
-	&& cd /usr/src/ossp-uuid \
-	&& ./configure \
-	    --prefix=/usr \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)"\
-	&& make install \
-	&& cd / \
+	&& ( \
+		cd /usr/src/ossp-uuid \
+		&& ./configure \
+			--prefix=/usr/local \
+		&& make -j "$(nproc)" \
+		&& make install \
+	) \
 	&& rm -rf /usr/src/ossp-uuid \
+	\
 	&& cd /usr/src/postgresql \
 # update "DEFAULT_PGSOCKET_DIR" to "/var/run/postgresql" (matching Debian)
 # see https://anonscm.debian.org/git/pkg-postgresql/postgresql.git/tree/debian/patches/51-default-sockets-in-var.patch?id=8b539fcb3e093a521c095e70bdfa76887217b89f
@@ -94,6 +99,8 @@ RUN set -ex \
 		--with-pgport=5432 \
 		--with-system-tzdata=/usr/share/zoneinfo \
 		--prefix=/usr/local \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
 		\
 # these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
 #		--with-krb5 \
@@ -106,7 +113,7 @@ RUN set -ex \
 		--with-openssl \
 		--with-libxml \
 		--with-libxslt \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" world \
+	&& make -j "$(nproc)" world \
 	&& make install-world \
 	&& make -C contrib install \
 	\

--- a/9.2/alpine/Dockerfile
+++ b/9.2/alpine/Dockerfile
@@ -17,6 +17,9 @@ ENV PG_MAJOR 9.2
 ENV PG_VERSION 9.2.20
 ENV PG_SHA256 0b8abdae8400cabea5587a726003c9dd71c73c049bdae523abc35f9312dd8f26
 
+ENV OSSP_UUID_VERSION 1.6.2
+ENV OSSP_UUID_SHA256 11a615225baa5f8bb686824423f50e4427acd3f70d394765bdff32801f0fd5b0
+
 RUN set -ex \
 	\
 	&& apk add --no-cache --virtual .fetch-deps \
@@ -54,6 +57,22 @@ RUN set -ex \
 		util-linux-dev \
 		zlib-dev \
 	\
+    && wget -O uuid.tar.gz "http://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/uuid-$OSSP_UUID_VERSION.tar.gz" \
+	&& echo "$OSSP_UUID_SHA256 *uuid.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/src/ossp-uuid \
+	&& tar \
+		--extract \
+		--file uuid.tar.gz \
+		--directory /usr/src/ossp-uuid \
+		--strip-components 1 \
+	&& rm uuid.tar.gz \
+	&& cd /usr/src/ossp-uuid \
+	&& ./configure \
+	    --prefix=/usr \
+	&& make -j "$(getconf _NPROCESSORS_ONLN)"\
+	&& make install \
+	&& cd / \
+	&& rm -rf /usr/src/ossp-uuid \
 	&& cd /usr/src/postgresql \
 # update "DEFAULT_PGSOCKET_DIR" to "/var/run/postgresql" (matching Debian)
 # see https://anonscm.debian.org/git/pkg-postgresql/postgresql.git/tree/debian/patches/51-default-sockets-in-var.patch?id=8b539fcb3e093a521c095e70bdfa76887217b89f
@@ -67,11 +86,10 @@ RUN set -ex \
 #		--enable-nls \
 		--enable-integer-datetimes \
 		--enable-thread-safety \
-		--enable-tap-tests \
 # skip debugging info -- we want tiny size instead
 #		--enable-debug \
 		--disable-rpath \
-		--with-uuid=e2fs \
+		--with-ossp-uuid \
 		--with-gnu-ld \
 		--with-pgport=5432 \
 		--with-system-tzdata=/usr/share/zoneinfo \

--- a/9.3/alpine/Dockerfile
+++ b/9.3/alpine/Dockerfile
@@ -39,6 +39,7 @@ RUN set -ex \
 	\
 	&& apk add --no-cache --virtual .build-deps \
 		bison \
+		coreutils \
 		flex \
 		gcc \
 #		krb5-dev \
@@ -57,7 +58,9 @@ RUN set -ex \
 		util-linux-dev \
 		zlib-dev \
 	\
-    && wget -O uuid.tar.gz "http://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/uuid-$OSSP_UUID_VERSION.tar.gz" \
+# install OSSP uuid (http://www.ossp.org/pkg/lib/uuid/)
+# see https://github.com/docker-library/postgres/pull/255 for more details
+	&& wget -O uuid.tar.gz "https://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/uuid-$OSSP_UUID_VERSION.tar.gz" \
 	&& echo "$OSSP_UUID_SHA256 *uuid.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/src/ossp-uuid \
 	&& tar \
@@ -66,13 +69,15 @@ RUN set -ex \
 		--directory /usr/src/ossp-uuid \
 		--strip-components 1 \
 	&& rm uuid.tar.gz \
-	&& cd /usr/src/ossp-uuid \
-	&& ./configure \
-	    --prefix=/usr \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)"\
-	&& make install \
-	&& cd / \
+	&& ( \
+		cd /usr/src/ossp-uuid \
+		&& ./configure \
+			--prefix=/usr/local \
+		&& make -j "$(nproc)" \
+		&& make install \
+	) \
 	&& rm -rf /usr/src/ossp-uuid \
+	\
 	&& cd /usr/src/postgresql \
 # update "DEFAULT_PGSOCKET_DIR" to "/var/run/postgresql" (matching Debian)
 # see https://anonscm.debian.org/git/pkg-postgresql/postgresql.git/tree/debian/patches/51-default-sockets-in-var.patch?id=8b539fcb3e093a521c095e70bdfa76887217b89f
@@ -94,6 +99,8 @@ RUN set -ex \
 		--with-pgport=5432 \
 		--with-system-tzdata=/usr/share/zoneinfo \
 		--prefix=/usr/local \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
 		\
 # these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
 #		--with-krb5 \
@@ -106,7 +113,7 @@ RUN set -ex \
 		--with-openssl \
 		--with-libxml \
 		--with-libxslt \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" world \
+	&& make -j "$(nproc)" world \
 	&& make install-world \
 	&& make -C contrib install \
 	\

--- a/9.3/alpine/Dockerfile
+++ b/9.3/alpine/Dockerfile
@@ -17,6 +17,9 @@ ENV PG_MAJOR 9.3
 ENV PG_VERSION 9.3.16
 ENV PG_SHA256 845f5e4ac8cf026b6a77c5a180a2fe869f51e9d06acf8d0365b05505a2c66873
 
+ENV OSSP_UUID_VERSION 1.6.2
+ENV OSSP_UUID_SHA256 11a615225baa5f8bb686824423f50e4427acd3f70d394765bdff32801f0fd5b0
+
 RUN set -ex \
 	\
 	&& apk add --no-cache --virtual .fetch-deps \
@@ -54,6 +57,22 @@ RUN set -ex \
 		util-linux-dev \
 		zlib-dev \
 	\
+    && wget -O uuid.tar.gz "http://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/uuid-$OSSP_UUID_VERSION.tar.gz" \
+	&& echo "$OSSP_UUID_SHA256 *uuid.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/src/ossp-uuid \
+	&& tar \
+		--extract \
+		--file uuid.tar.gz \
+		--directory /usr/src/ossp-uuid \
+		--strip-components 1 \
+	&& rm uuid.tar.gz \
+	&& cd /usr/src/ossp-uuid \
+	&& ./configure \
+	    --prefix=/usr \
+	&& make -j "$(getconf _NPROCESSORS_ONLN)"\
+	&& make install \
+	&& cd / \
+	&& rm -rf /usr/src/ossp-uuid \
 	&& cd /usr/src/postgresql \
 # update "DEFAULT_PGSOCKET_DIR" to "/var/run/postgresql" (matching Debian)
 # see https://anonscm.debian.org/git/pkg-postgresql/postgresql.git/tree/debian/patches/51-default-sockets-in-var.patch?id=8b539fcb3e093a521c095e70bdfa76887217b89f
@@ -67,11 +86,10 @@ RUN set -ex \
 #		--enable-nls \
 		--enable-integer-datetimes \
 		--enable-thread-safety \
-		--enable-tap-tests \
 # skip debugging info -- we want tiny size instead
 #		--enable-debug \
 		--disable-rpath \
-		--with-uuid=e2fs \
+		--with-ossp-uuid \
 		--with-gnu-ld \
 		--with-pgport=5432 \
 		--with-system-tzdata=/usr/share/zoneinfo \

--- a/9.4/alpine/Dockerfile
+++ b/9.4/alpine/Dockerfile
@@ -36,6 +36,7 @@ RUN set -ex \
 	\
 	&& apk add --no-cache --virtual .build-deps \
 		bison \
+		coreutils \
 		flex \
 		gcc \
 #		krb5-dev \
@@ -76,6 +77,8 @@ RUN set -ex \
 		--with-pgport=5432 \
 		--with-system-tzdata=/usr/share/zoneinfo \
 		--prefix=/usr/local \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
 		\
 # these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
 #		--with-krb5 \
@@ -88,7 +91,7 @@ RUN set -ex \
 		--with-openssl \
 		--with-libxml \
 		--with-libxslt \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" world \
+	&& make -j "$(nproc)" world \
 	&& make install-world \
 	&& make -C contrib install \
 	\

--- a/9.5/alpine/Dockerfile
+++ b/9.5/alpine/Dockerfile
@@ -36,6 +36,7 @@ RUN set -ex \
 	\
 	&& apk add --no-cache --virtual .build-deps \
 		bison \
+		coreutils \
 		flex \
 		gcc \
 #		krb5-dev \
@@ -76,6 +77,8 @@ RUN set -ex \
 		--with-pgport=5432 \
 		--with-system-tzdata=/usr/share/zoneinfo \
 		--prefix=/usr/local \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
 		\
 # these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
 #		--with-krb5 \
@@ -88,7 +91,7 @@ RUN set -ex \
 		--with-openssl \
 		--with-libxml \
 		--with-libxslt \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" world \
+	&& make -j "$(nproc)" world \
 	&& make install-world \
 	&& make -C contrib install \
 	\

--- a/9.6/alpine/Dockerfile
+++ b/9.6/alpine/Dockerfile
@@ -36,6 +36,7 @@ RUN set -ex \
 	\
 	&& apk add --no-cache --virtual .build-deps \
 		bison \
+		coreutils \
 		flex \
 		gcc \
 #		krb5-dev \
@@ -76,6 +77,8 @@ RUN set -ex \
 		--with-pgport=5432 \
 		--with-system-tzdata=/usr/share/zoneinfo \
 		--prefix=/usr/local \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
 		\
 # these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
 #		--with-krb5 \
@@ -88,7 +91,7 @@ RUN set -ex \
 		--with-openssl \
 		--with-libxml \
 		--with-libxslt \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" world \
+	&& make -j "$(nproc)" world \
 	&& make install-world \
 	&& make -C contrib install \
 	\

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -37,6 +37,7 @@ RUN set -ex \
 	\
 	&& apk add --no-cache --virtual .build-deps \
 		bison \
+		coreutils \
 		flex \
 		gcc \
 #		krb5-dev \
@@ -55,7 +56,7 @@ RUN set -ex \
 		util-linux-dev \
 		zlib-dev \
 	\
-	%%INSTALL_OSSP_UUID%%
+%%INSTALL_OSSP_UUID%%
 	&& cd /usr/src/postgresql \
 # update "DEFAULT_PGSOCKET_DIR" to "/var/run/postgresql" (matching Debian)
 # see https://anonscm.debian.org/git/pkg-postgresql/postgresql.git/tree/debian/patches/51-default-sockets-in-var.patch?id=8b539fcb3e093a521c095e70bdfa76887217b89f
@@ -78,6 +79,8 @@ RUN set -ex \
 		--with-pgport=5432 \
 		--with-system-tzdata=/usr/share/zoneinfo \
 		--prefix=/usr/local \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
 		\
 # these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
 #		--with-krb5 \
@@ -90,7 +93,7 @@ RUN set -ex \
 		--with-openssl \
 		--with-libxml \
 		--with-libxslt \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" world \
+	&& make -j "$(nproc)" world \
 	&& make install-world \
 	&& make -C contrib install \
 	\

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -17,6 +17,7 @@ ENV PG_MAJOR %%PG_MAJOR%%
 ENV PG_VERSION %%PG_VERSION%%
 ENV PG_SHA256 %%PG_SHA256%%
 
+%%OSSP_UUID_ENV_VARS%%
 RUN set -ex \
 	\
 	&& apk add --no-cache --virtual .fetch-deps \
@@ -54,6 +55,7 @@ RUN set -ex \
 		util-linux-dev \
 		zlib-dev \
 	\
+	%%INSTALL_OSSP_UUID%%
 	&& cd /usr/src/postgresql \
 # update "DEFAULT_PGSOCKET_DIR" to "/var/run/postgresql" (matching Debian)
 # see https://anonscm.debian.org/git/pkg-postgresql/postgresql.git/tree/debian/patches/51-default-sockets-in-var.patch?id=8b539fcb3e093a521c095e70bdfa76887217b89f
@@ -71,7 +73,7 @@ RUN set -ex \
 # skip debugging info -- we want tiny size instead
 #		--enable-debug \
 		--disable-rpath \
-		--with-uuid=e2fs \
+		%%UUID_CONFIG_FLAG%% \
 		--with-gnu-ld \
 		--with-pgport=5432 \
 		--with-system-tzdata=/usr/share/zoneinfo \

--- a/ossp-uuid.template
+++ b/ossp-uuid.template
@@ -1,0 +1,16 @@
+    && wget -O uuid.tar.gz "http://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/uuid-$OSSP_UUID_VERSION.tar.gz" \
+	&& echo "$OSSP_UUID_SHA256 *uuid.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/src/ossp-uuid \
+	&& tar \
+		--extract \
+		--file uuid.tar.gz \
+		--directory /usr/src/ossp-uuid \
+		--strip-components 1 \
+	&& rm uuid.tar.gz \
+	&& cd /usr/src/ossp-uuid \
+	&& ./configure \
+	    --prefix=/usr \
+	&& make -j "$(getconf _NPROCESSORS_ONLN)"\
+	&& make install \
+	&& cd / \
+	&& rm -rf /usr/src/ossp-uuid \

--- a/ossp-uuid.template
+++ b/ossp-uuid.template
@@ -1,4 +1,6 @@
-    && wget -O uuid.tar.gz "http://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/uuid-$OSSP_UUID_VERSION.tar.gz" \
+# install OSSP uuid (http://www.ossp.org/pkg/lib/uuid/)
+# see https://github.com/docker-library/postgres/pull/255 for more details
+	&& wget -O uuid.tar.gz "https://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/uuid-$OSSP_UUID_VERSION.tar.gz" \
 	&& echo "$OSSP_UUID_SHA256 *uuid.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/src/ossp-uuid \
 	&& tar \
@@ -7,10 +9,12 @@
 		--directory /usr/src/ossp-uuid \
 		--strip-components 1 \
 	&& rm uuid.tar.gz \
-	&& cd /usr/src/ossp-uuid \
-	&& ./configure \
-	    --prefix=/usr \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)"\
-	&& make install \
-	&& cd / \
+	&& ( \
+		cd /usr/src/ossp-uuid \
+		&& ./configure \
+			--prefix=/usr/local \
+		&& make -j "$(nproc)" \
+		&& make install \
+	) \
 	&& rm -rf /usr/src/ossp-uuid \
+	\

--- a/update.sh
+++ b/update.sh
@@ -12,6 +12,10 @@ versions=( "${versions[@]%/}" )
 packagesBase='http://apt.postgresql.org/pub/repos/apt/dists/jessie-pgdg'
 mainList="$(curl -fsSL "$packagesBase/main/binary-amd64/Packages.bz2" | bunzip2)"
 
+uuidConfigFlag="--with-uuid=e2fs"
+osspUuidVersion='1.6.2'
+osspUuidHash='11a615225baa5f8bb686824423f50e4427acd3f70d394765bdff32801f0fd5b0'
+
 travisEnv=
 for version in "${versions[@]}"; do
 	versionList="$(echo "$mainList"; curl -fsSL "$packagesBase/$version/binary-amd64/Packages.bz2" | bunzip2)"
@@ -34,6 +38,16 @@ for version in "${versions[@]}"; do
 			cp docker-entrypoint.sh "$version/$variant/"
 			sed -i 's/gosu/su-exec/g' "$version/$variant/docker-entrypoint.sh"
 			sed 's/%%PG_MAJOR%%/'"$version"'/g; s/%%PG_VERSION%%/'"$srcVersion"'/g; s/%%PG_SHA256%%/'"$srcSha256"'/g' Dockerfile-$variant.template > "$version/$variant/Dockerfile"
+			if [[ $version =~ ^9.[23]$ ]]; then
+			    uuidConfigFlag='--with-ossp-uuid'
+			    sed -i 's/%%OSSP_UUID_ENV_VARS%%/ENV OSSP_UUID_VERSION '"$osspUuidVersion"'\nENV OSSP_UUID_SHA256 '"$osspUuidHash"'\n/' "$version/$variant/Dockerfile"
+			    sed -i $'/%%INSTALL_OSSP_UUID%%/ {r ossp-uuid.template\n d}' "$version/$variant/Dockerfile"
+			    sed -i '/--enable-tap-tests/d' "$version/$variant/Dockerfile"
+			fi
+			sed -i '/%%OSSP_UUID_ENV_VARS%%/d' "$version/$variant/Dockerfile"
+			sed -i '/%%INSTALL_OSSP_UUID%%/d' "$version/$variant/Dockerfile"
+			sed -i 's/%%UUID_CONFIG_FLAG%%/'"$uuidConfigFlag"'/' "$version/$variant/Dockerfile"
+
 		)
 		travisEnv="\n  - VERSION=$version VARIANT=$variant$travisEnv"
 	done

--- a/update.sh
+++ b/update.sh
@@ -12,7 +12,7 @@ versions=( "${versions[@]%/}" )
 packagesBase='http://apt.postgresql.org/pub/repos/apt/dists/jessie-pgdg'
 mainList="$(curl -fsSL "$packagesBase/main/binary-amd64/Packages.bz2" | bunzip2)"
 
-uuidConfigFlag="--with-uuid=e2fs"
+# https://www.mirrorservice.org/sites/ftp.ossp.org/pkg/lib/uuid/?C=M;O=D
 osspUuidVersion='1.6.2'
 osspUuidHash='11a615225baa5f8bb686824423f50e4427acd3f70d394765bdff32801f0fd5b0'
 
@@ -37,17 +37,29 @@ for version in "${versions[@]}"; do
 			set -x
 			cp docker-entrypoint.sh "$version/$variant/"
 			sed -i 's/gosu/su-exec/g' "$version/$variant/docker-entrypoint.sh"
-			sed 's/%%PG_MAJOR%%/'"$version"'/g; s/%%PG_VERSION%%/'"$srcVersion"'/g; s/%%PG_SHA256%%/'"$srcSha256"'/g' Dockerfile-$variant.template > "$version/$variant/Dockerfile"
-			if [[ $version =~ ^9.[23]$ ]]; then
-			    uuidConfigFlag='--with-ossp-uuid'
-			    sed -i 's/%%OSSP_UUID_ENV_VARS%%/ENV OSSP_UUID_VERSION '"$osspUuidVersion"'\nENV OSSP_UUID_SHA256 '"$osspUuidHash"'\n/' "$version/$variant/Dockerfile"
-			    sed -i $'/%%INSTALL_OSSP_UUID%%/ {r ossp-uuid.template\n d}' "$version/$variant/Dockerfile"
-			    sed -i '/--enable-tap-tests/d' "$version/$variant/Dockerfile"
-			fi
-			sed -i '/%%OSSP_UUID_ENV_VARS%%/d' "$version/$variant/Dockerfile"
-			sed -i '/%%INSTALL_OSSP_UUID%%/d' "$version/$variant/Dockerfile"
-			sed -i 's/%%UUID_CONFIG_FLAG%%/'"$uuidConfigFlag"'/' "$version/$variant/Dockerfile"
+			sed -e 's/%%PG_MAJOR%%/'"$version"'/g' \
+				-e 's/%%PG_VERSION%%/'"$srcVersion"'/g' \
+				-e 's/%%PG_SHA256%%/'"$srcSha256"'/g' \
+				"Dockerfile-$variant.template" > "$version/$variant/Dockerfile"
 
+			# TODO remove all this when 9.2 and 9.3 are EOL (2017-10-01 and 2018-10-01 -- from http://www.postgresql.org/support/versioning/)
+			case "$version" in
+				9.2|9.3)
+					uuidConfigFlag='--with-ossp-uuid'
+					sed -i 's/%%OSSP_UUID_ENV_VARS%%/ENV OSSP_UUID_VERSION '"$osspUuidVersion"'\nENV OSSP_UUID_SHA256 '"$osspUuidHash"'\n/' "$version/$variant/Dockerfile"
+					sed -i $'/%%INSTALL_OSSP_UUID%%/ {r ossp-uuid.template\n d}' "$version/$variant/Dockerfile"
+
+					# configure: WARNING: unrecognized options: --enable-tap-tests
+					sed -i '/--enable-tap-tests/d' "$version/$variant/Dockerfile"
+					;;
+
+				*)
+					uuidConfigFlag='--with-uuid=e2fs'
+					sed -i '/%%OSSP_UUID_ENV_VARS%%/d' "$version/$variant/Dockerfile"
+					sed -i '/%%INSTALL_OSSP_UUID%%/d' "$version/$variant/Dockerfile"
+					;;
+			esac
+			sed -i 's/%%UUID_CONFIG_FLAG%%/'"$uuidConfigFlag"'/' "$version/$variant/Dockerfile"
 		)
 		travisEnv="\n  - VERSION=$version VARIANT=$variant$travisEnv"
 	done


### PR DESCRIPTION
The 9.3 alpine image builds postgres with all the extensions (`make install-world`) but it's missing `--with-ossp-uuid`.
Just adding it is not enough because it seems like `uuid.h` from `util-linux-dev` doesn't satisfy the check for `libuuid`, it's looking for `uuid_export` which isn't present in that version of `uuid.h`.
```
checking for uuid_export in -lossp-uuid... no
checking for uuid_export in -luuid... no
configure: error: library 'ossp-uuid' or 'uuid' is required for OSSP-UUID
``` 

Because of this, I added ossp-uuid to the image. I had to use a mirror because the official ftp server is not reliable (it often fails with `CONNECTION_REFUSED`).
It also doesn't increase the size of the image significantly (+0.2 MB).

```
REPOSITORY                  TAG                           IMAGE ID            CREATED             SIZE
postgres                    9.3-alpine                    da793c57faa1        3 minutes ago       35.3 MB
postgres                    9.3-alpine-ossp-uuid          c3f3d3cd3d52        20 minutes ago      35.5 MB
```

I also removed 2 of the configure flags since they're not recognized : 
```
configure: WARNING: unrecognized options: --enable-tap-tests, --with-uuid
```