### PR TITLE
✨ Add $POSTGRES_CONF env var support

### DIFF
--- a/9.2/alpine/docker-entrypoint.sh
+++ b/9.2/alpine/docker-entrypoint.sh
@@ -119,6 +119,10 @@ if [ "$1" = 'postgres' ]; then
 
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
+		if [ -n "$POSTGRES_CONF" ]; then
+			echo "$POSTGRES_CONF" > "$PGDATA/postgresql.conf"
+		fi
+
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -119,6 +119,10 @@ if [ "$1" = 'postgres' ]; then
 
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
+		if [ -n "$POSTGRES_CONF" ]; then
+			echo "$POSTGRES_CONF" > "$PGDATA/postgresql.conf"
+		fi
+
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in

--- a/9.3/alpine/docker-entrypoint.sh
+++ b/9.3/alpine/docker-entrypoint.sh
@@ -119,6 +119,10 @@ if [ "$1" = 'postgres' ]; then
 
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
+		if [ -n "$POSTGRES_CONF" ]; then
+			echo "$POSTGRES_CONF" > "$PGDATA/postgresql.conf"
+		fi
+
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -119,6 +119,10 @@ if [ "$1" = 'postgres' ]; then
 
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
+		if [ -n "$POSTGRES_CONF" ]; then
+			echo "$POSTGRES_CONF" > "$PGDATA/postgresql.conf"
+		fi
+
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in

--- a/9.4/alpine/docker-entrypoint.sh
+++ b/9.4/alpine/docker-entrypoint.sh
@@ -119,6 +119,10 @@ if [ "$1" = 'postgres' ]; then
 
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
+		if [ -n "$POSTGRES_CONF" ]; then
+			echo "$POSTGRES_CONF" > "$PGDATA/postgresql.conf"
+		fi
+
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -119,6 +119,10 @@ if [ "$1" = 'postgres' ]; then
 
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
+		if [ -n "$POSTGRES_CONF" ]; then
+			echo "$POSTGRES_CONF" > "$PGDATA/postgresql.conf"
+		fi
+
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in

--- a/9.5/alpine/docker-entrypoint.sh
+++ b/9.5/alpine/docker-entrypoint.sh
@@ -119,6 +119,10 @@ if [ "$1" = 'postgres' ]; then
 
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
+		if [ -n "$POSTGRES_CONF" ]; then
+			echo "$POSTGRES_CONF" > "$PGDATA/postgresql.conf"
+		fi
+
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -119,6 +119,10 @@ if [ "$1" = 'postgres' ]; then
 
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
+		if [ -n "$POSTGRES_CONF" ]; then
+			echo "$POSTGRES_CONF" > "$PGDATA/postgresql.conf"
+		fi
+
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in

--- a/9.6/alpine/docker-entrypoint.sh
+++ b/9.6/alpine/docker-entrypoint.sh
@@ -119,6 +119,10 @@ if [ "$1" = 'postgres' ]; then
 
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
+		if [ -n "$POSTGRES_CONF" ]; then
+			echo "$POSTGRES_CONF" > "$PGDATA/postgresql.conf"
+		fi
+
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -119,6 +119,10 @@ if [ "$1" = 'postgres' ]; then
 
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
+		if [ -n "$POSTGRES_CONF" ]; then
+			echo "$POSTGRES_CONF" > "$PGDATA/postgresql.conf"
+		fi
+
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -119,6 +119,10 @@ if [ "$1" = 'postgres' ]; then
 
 		psql+=( --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" )
 
+		if [ -n "$POSTGRES_CONF" ]; then
+			echo "$POSTGRES_CONF" > "$PGDATA/postgresql.conf"
+		fi
+
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in


### PR DESCRIPTION
This variable, if set, enforces certain configuration each time the container is booted.

Current design of this image presents some problems when deploying:

- "Nobody knows" 😆 where does the `$PGDATA/postgresql.conf` file comes from and why does it have those settings, but they might not be what you desire/need.
- Configuration is stored in a volume, which could be cool under some circumstances, but uncool under others, like if you need to change config, you need to enter the volume and change manually, instead of just mounting the same volume on a new & properly configured container.
- There's actually no standard way of configuring your Postgres.
  - Yes, you can add scripts to `/docker-entrypoint-initdb.d/*` that configure your server, but what if you want to configure an already-running instance?
  - Yes, you can copy your file to `/etc/postgres/postgresql.conf` in a subimage and then run the container with some command that tells postgres where to find that file, but [Postgres already has its default (`$PGDATA/postgresql.conf`)](https://www.postgresql.org/docs/current/static/runtime-config-file-locations.html), so why not just use it?

With this patch, you still have the settings stored in the volume, but each time the container boots, it overrides the configuration if it is asked to do so, so you certainly know that if you run for example this:

```bash
docker container run --rm -it -e POSTGRES_CONF='
max_connections = 200
shared_buffers = 1GB
effective_cache_size = 3GB
work_mem = 5242kB
maintenance_work_mem = 256MB
min_wal_size = 1GB
max_wal_size = 2GB
checkpoint_completion_target = 0.7
wal_buffers = 16MB
default_statistics_target = 100
' postgres
```

... you'll get a running postgresql server **with that configuration**.

Of course, this should get documented when merged.