### PR TITLE
Dockerfile: Use apk packages for postgres.

### DIFF
--- a/9.6/alpine/Dockerfile
+++ b/9.6/alpine/Dockerfile
@@ -18,111 +18,20 @@ ENV PG_VERSION 9.6.2
 ENV PG_SHA256 0187b5184be1c09034e74e44761505e52357248451b0c854dddec6c231fe50c9
 
 RUN set -ex \
-	\
-	&& apk add --no-cache --virtual .fetch-deps \
+	&& apk add --no-cache \
 		ca-certificates \
 		openssl \
 		tar \
-	\
-	&& wget -O postgresql.tar.bz2 "https://ftp.postgresql.org/pub/source/v$PG_VERSION/postgresql-$PG_VERSION.tar.bz2" \
-	&& echo "$PG_SHA256 *postgresql.tar.bz2" | sha256sum -c - \
-	&& mkdir -p /usr/src/postgresql \
-	&& tar \
-		--extract \
-		--file postgresql.tar.bz2 \
-		--directory /usr/src/postgresql \
-		--strip-components 1 \
-	&& rm postgresql.tar.bz2 \
-	\
-	&& apk add --no-cache --virtual .build-deps \
-		bison \
-		coreutils \
-		flex \
-		gcc \
-#		krb5-dev \
-		libc-dev \
-		libedit-dev \
-		libxml2-dev \
-		libxslt-dev \
-		make \
-#		openldap-dev \
-		openssl-dev \
-		perl \
-#		perl-dev \
-#		python-dev \
-#		python3-dev \
-#		tcl-dev \
-		util-linux-dev \
-		zlib-dev \
-	\
-	&& cd /usr/src/postgresql \
-# update "DEFAULT_PGSOCKET_DIR" to "/var/run/postgresql" (matching Debian)
-# see https://anonscm.debian.org/git/pkg-postgresql/postgresql.git/tree/debian/patches/51-default-sockets-in-var.patch?id=8b539fcb3e093a521c095e70bdfa76887217b89f
-	&& awk '$1 == "#define" && $2 == "DEFAULT_PGSOCKET_DIR" && $3 == "\"/tmp\"" { $3 = "\"/var/run/postgresql\""; print; next } { print }' src/include/pg_config_manual.h > src/include/pg_config_manual.h.new \
-	&& grep '/var/run/postgresql' src/include/pg_config_manual.h.new \
-	&& mv src/include/pg_config_manual.h.new src/include/pg_config_manual.h \
-# configure options taken from:
-# https://anonscm.debian.org/cgit/pkg-postgresql/postgresql.git/tree/debian/rules?h=9.5
-	&& ./configure \
-# "/usr/src/postgresql/src/backend/access/common/tupconvert.c:105: undefined reference to `libintl_gettext'"
-#		--enable-nls \
-		--enable-integer-datetimes \
-		--enable-thread-safety \
-		--enable-tap-tests \
-# skip debugging info -- we want tiny size instead
-#		--enable-debug \
-		--disable-rpath \
-		--with-uuid=e2fs \
-		--with-gnu-ld \
-		--with-pgport=5432 \
-		--with-system-tzdata=/usr/share/zoneinfo \
-		--prefix=/usr/local \
-		--with-includes=/usr/local/include \
-		--with-libraries=/usr/local/lib \
-		\
-# these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
-#		--with-krb5 \
-#		--with-gssapi \
-#		--with-ldap \
-#		--with-tcl \
-#		--with-perl \
-#		--with-python \
-#		--with-pam \
-		--with-openssl \
-		--with-libxml \
-		--with-libxslt \
-	&& make -j "$(nproc)" world \
-	&& make install-world \
-	&& make -C contrib install \
-	\
-	&& runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
-			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
-	)" \
-	&& apk add --no-cache --virtual .postgresql-rundeps \
-		$runDeps \
 		bash \
 		su-exec \
-# tzdata is optional, but only adds around 1Mb to image size and is recommended by Django documentation:
-# https://docs.djangoproject.com/en/1.10/ref/databases/#optimizing-postgresql-s-configuration
 		tzdata \
-	&& apk del .fetch-deps .build-deps \
-	&& cd / \
-	&& rm -rf \
-		/usr/src/postgresql \
-		/usr/local/share/doc \
-		/usr/local/share/man \
-	&& find /usr/local -name '*.a' -delete
+	&& apk add --no-cache postgresql postgresql-contrib
 
 # make the sample config easier to munge (and "correct by default")
-RUN sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/local/share/postgresql/postgresql.conf.sample
+RUN sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/share/postgresql/postgresql.conf.sample
 
 RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod g+s /var/run/postgresql
 
-ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
 VOLUME /var/lib/postgresql/data


### PR DESCRIPTION
Alpine 3.5 ships with Postgres 9.6 as its default package version so just use the built in APK.