### PR TITLE
Adjust "/var/run/postgresql" permissions for arbitrary-user support

### DIFF
--- a/9.2/Dockerfile
+++ b/9.2/Dockerfile
@@ -54,7 +54,7 @@ RUN mv -v /usr/share/postgresql/$PG_MAJOR/postgresql.conf.sample /usr/share/post
 	&& ln -sv ../postgresql.conf.sample /usr/share/postgresql/$PG_MAJOR/ \
 	&& sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/share/postgresql/postgresql.conf.sample
 
-RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod g+s /var/run/postgresql
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data

--- a/9.2/alpine/Dockerfile
+++ b/9.2/alpine/Dockerfile
@@ -161,7 +161,7 @@ RUN set -ex \
 # make the sample config easier to munge (and "correct by default")
 RUN sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/local/share/postgresql/postgresql.conf.sample
 
-RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod g+s /var/run/postgresql
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data

--- a/9.2/alpine/docker-entrypoint.sh
+++ b/9.2/alpine/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
-	chmod g+s /var/run/postgresql
+	chmod 775 /var/run/postgresql
 
 	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then

--- a/9.2/docker-entrypoint.sh
+++ b/9.2/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
-	chmod g+s /var/run/postgresql
+	chmod 775 /var/run/postgresql
 
 	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then

--- a/9.3/Dockerfile
+++ b/9.3/Dockerfile
@@ -54,7 +54,7 @@ RUN mv -v /usr/share/postgresql/$PG_MAJOR/postgresql.conf.sample /usr/share/post
 	&& ln -sv ../postgresql.conf.sample /usr/share/postgresql/$PG_MAJOR/ \
 	&& sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/share/postgresql/postgresql.conf.sample
 
-RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod g+s /var/run/postgresql
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data

--- a/9.3/alpine/Dockerfile
+++ b/9.3/alpine/Dockerfile
@@ -161,7 +161,7 @@ RUN set -ex \
 # make the sample config easier to munge (and "correct by default")
 RUN sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/local/share/postgresql/postgresql.conf.sample
 
-RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod g+s /var/run/postgresql
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data

--- a/9.3/alpine/docker-entrypoint.sh
+++ b/9.3/alpine/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
-	chmod g+s /var/run/postgresql
+	chmod 775 /var/run/postgresql
 
 	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
-	chmod g+s /var/run/postgresql
+	chmod 775 /var/run/postgresql
 
 	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then

--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -54,7 +54,7 @@ RUN mv -v /usr/share/postgresql/$PG_MAJOR/postgresql.conf.sample /usr/share/post
 	&& ln -sv ../postgresql.conf.sample /usr/share/postgresql/$PG_MAJOR/ \
 	&& sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/share/postgresql/postgresql.conf.sample
 
-RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod g+s /var/run/postgresql
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data

--- a/9.4/alpine/Dockerfile
+++ b/9.4/alpine/Dockerfile
@@ -134,7 +134,7 @@ RUN set -ex \
 # make the sample config easier to munge (and "correct by default")
 RUN sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/local/share/postgresql/postgresql.conf.sample
 
-RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod g+s /var/run/postgresql
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data

--- a/9.4/alpine/docker-entrypoint.sh
+++ b/9.4/alpine/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
-	chmod g+s /var/run/postgresql
+	chmod 775 /var/run/postgresql
 
 	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
-	chmod g+s /var/run/postgresql
+	chmod 775 /var/run/postgresql
 
 	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -54,7 +54,7 @@ RUN mv -v /usr/share/postgresql/$PG_MAJOR/postgresql.conf.sample /usr/share/post
 	&& ln -sv ../postgresql.conf.sample /usr/share/postgresql/$PG_MAJOR/ \
 	&& sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/share/postgresql/postgresql.conf.sample
 
-RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod g+s /var/run/postgresql
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data

--- a/9.5/alpine/Dockerfile
+++ b/9.5/alpine/Dockerfile
@@ -134,7 +134,7 @@ RUN set -ex \
 # make the sample config easier to munge (and "correct by default")
 RUN sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/local/share/postgresql/postgresql.conf.sample
 
-RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod g+s /var/run/postgresql
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data

--- a/9.5/alpine/docker-entrypoint.sh
+++ b/9.5/alpine/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
-	chmod g+s /var/run/postgresql
+	chmod 775 /var/run/postgresql
 
 	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
-	chmod g+s /var/run/postgresql
+	chmod 775 /var/run/postgresql
 
 	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then

--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -54,7 +54,7 @@ RUN mv -v /usr/share/postgresql/$PG_MAJOR/postgresql.conf.sample /usr/share/post
 	&& ln -sv ../postgresql.conf.sample /usr/share/postgresql/$PG_MAJOR/ \
 	&& sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/share/postgresql/postgresql.conf.sample
 
-RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod g+s /var/run/postgresql
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data

--- a/9.6/alpine/Dockerfile
+++ b/9.6/alpine/Dockerfile
@@ -134,7 +134,7 @@ RUN set -ex \
 # make the sample config easier to munge (and "correct by default")
 RUN sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/local/share/postgresql/postgresql.conf.sample
 
-RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod g+s /var/run/postgresql
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data

--- a/9.6/alpine/docker-entrypoint.sh
+++ b/9.6/alpine/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
-	chmod g+s /var/run/postgresql
+	chmod 775 /var/run/postgresql
 
 	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
-	chmod g+s /var/run/postgresql
+	chmod 775 /var/run/postgresql
 
 	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -136,7 +136,7 @@ RUN set -ex \
 # make the sample config easier to munge (and "correct by default")
 RUN sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/local/share/postgresql/postgresql.conf.sample
 
-RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod g+s /var/run/postgresql
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -54,7 +54,7 @@ RUN mv -v /usr/share/postgresql/$PG_MAJOR/postgresql.conf.sample /usr/share/post
 	&& ln -sv ../postgresql.conf.sample /usr/share/postgresql/$PG_MAJOR/ \
 	&& sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/share/postgresql/postgresql.conf.sample
 
-RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod g+s /var/run/postgresql
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
 
 ENV PATH /usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 ENV PGDATA /var/lib/postgresql/data

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,7 +35,7 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
-	chmod g+s /var/run/postgresql
+	chmod 775 /var/run/postgresql
 
 	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then

--- a/update.sh
+++ b/update.sh
@@ -46,8 +46,10 @@ for version in "${versions[@]}"; do
 			case "$version" in
 				9.2|9.3)
 					uuidConfigFlag='--with-ossp-uuid'
-					sed -i 's/%%OSSP_UUID_ENV_VARS%%/ENV OSSP_UUID_VERSION '"$osspUuidVersion"'\nENV OSSP_UUID_SHA256 '"$osspUuidHash"'\n/' "$version/$variant/Dockerfile"
-					sed -i $'/%%INSTALL_OSSP_UUID%%/ {r ossp-uuid.template\n d}' "$version/$variant/Dockerfile"
+					sed -i \
+						-e 's/%%OSSP_UUID_ENV_VARS%%/ENV OSSP_UUID_VERSION '"$osspUuidVersion"'\nENV OSSP_UUID_SHA256 '"$osspUuidHash"'\n/' \
+						-e $'/%%INSTALL_OSSP_UUID%%/ {r ossp-uuid.template\n d}' \
+						"$version/$variant/Dockerfile"
 
 					# configure: WARNING: unrecognized options: --enable-tap-tests
 					sed -i '/--enable-tap-tests/d' "$version/$variant/Dockerfile"
@@ -55,8 +57,10 @@ for version in "${versions[@]}"; do
 
 				*)
 					uuidConfigFlag='--with-uuid=e2fs'
-					sed -i '/%%OSSP_UUID_ENV_VARS%%/d' "$version/$variant/Dockerfile"
-					sed -i '/%%INSTALL_OSSP_UUID%%/d' "$version/$variant/Dockerfile"
+					sed -i \
+						-e '/%%OSSP_UUID_ENV_VARS%%/d' \
+						-e '/%%INSTALL_OSSP_UUID%%/d' \
+						"$version/$variant/Dockerfile"
 					;;
 			esac
 			sed -i 's/%%UUID_CONFIG_FLAG%%/'"$uuidConfigFlag"'/' "$version/$variant/Dockerfile"


### PR DESCRIPTION
Fixes #264

Before:

```console
$ rm -rf ~/wtf && mkdir -p ~/wtf && docker run -it --rm --name test --user "$(id -u):$(id -g)" -v /etc/passwd:/etc/passwd:ro -v "$HOME/wtf":/var/lib/postgresql/data postgres:9.6
The files belonging to this database system will be owned by user "tianon".
This user must also own the server process.

The database cluster will be initialized with locale "en_US.utf8".
The default database encoding has accordingly been set to "UTF8".
The default text search configuration will be set to "english".

Data page checksums are disabled.

fixing permissions on existing directory /var/lib/postgresql/data ... ok
creating subdirectories ... ok
selecting default max_connections ... 100
selecting default shared_buffers ... 128MB
selecting dynamic shared memory implementation ... posix
creating configuration files ... ok
running bootstrap script ... ok
performing post-bootstrap initialization ... ok
syncing data to disk ... ok

WARNING: enabling "trust" authentication for local connections
You can change this by editing pg_hba.conf or using the option -A, or
--auth-local and --auth-host, the next time you run initdb.

Success. You can now start the database server using:

    pg_ctl -D /var/lib/postgresql/data -l logfile start

****************************************************
WARNING: No password has been set for the database.
         This will allow anyone with access to the
         Postgres port to access your database. In
         Docker's default configuration, this is
         effectively any other container on the same
         system.

         Use "-e POSTGRES_PASSWORD=password" to set
         it in "docker run".
****************************************************
waiting for server to start....LOG:  could not bind IPv6 socket: Cannot assign requested address
HINT:  Is another postmaster already running on port 5432? If not, wait a few seconds and retry.
FATAL:  could not create lock file "/var/run/postgresql/.s.PGSQL.5432.lock": Permission denied
LOG:  database system is shut down
 stopped waiting
pg_ctl: could not start server
Examine the log output.
```

After:

```console
$ rm -rf ~/wtf && mkdir -p ~/wtf && docker run -it --rm --name test --user "$(id -u):$(id -g)" -v /etc/passwd:/etc/passwd:ro -v "$HOME/wtf":/var/lib/postgresql/data edee229acce4
The files belonging to this database system will be owned by user "tianon".
This user must also own the server process.

The database cluster will be initialized with locale "en_US.utf8".
The default database encoding has accordingly been set to "UTF8".
The default text search configuration will be set to "english".

Data page checksums are disabled.

fixing permissions on existing directory /var/lib/postgresql/data ... ok
creating subdirectories ... ok
selecting default max_connections ... 100
selecting default shared_buffers ... 128MB
selecting dynamic shared memory implementation ... posix
creating configuration files ... ok
running bootstrap script ... ok
performing post-bootstrap initialization ... ok
syncing data to disk ... ok

WARNING: enabling "trust" authentication for local connections
You can change this by editing pg_hba.conf or using the option -A, or
--auth-local and --auth-host, the next time you run initdb.

Success. You can now start the database server using:

    pg_ctl -D /var/lib/postgresql/data -l logfile start

****************************************************
WARNING: No password has been set for the database.
         This will allow anyone with access to the
         Postgres port to access your database. In
         Docker's default configuration, this is
         effectively any other container on the same
         system.

         Use "-e POSTGRES_PASSWORD=password" to set
         it in "docker run".
****************************************************
waiting for server to start....LOG:  could not bind IPv6 socket: Cannot assign requested address
HINT:  Is another postmaster already running on port 5432? If not, wait a few seconds and retry.
LOG:  database system was shut down at 2017-05-19 17:48:43 UTC
LOG:  MultiXact member wraparound protections are now enabled
LOG:  autovacuum launcher started
LOG:  database system is ready to accept connections
 done
server started
ALTER ROLE


/usr/local/bin/docker-entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*

LOG:  received fast shutdown request
LOG:  aborting any active transactions
LOG:  autovacuum launcher shutting down
waiting for server to shut down....LOG:  shutting down
LOG:  database system is shut down
 done
server stopped

PostgreSQL init process complete; ready for start up.

LOG:  database system was shut down at 2017-05-19 17:48:45 UTC
LOG:  MultiXact member wraparound protections are now enabled
LOG:  autovacuum launcher started
LOG:  database system is ready to accept connections
```