### PR TITLE
Remove unnecessary line that will always error

### DIFF
--- a/9.4/alpine/docker-entrypoint.sh
+++ b/9.4/alpine/docker-entrypoint.sh
@@ -49,7 +49,6 @@ fi
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
 	chmod 700 "$PGDATA" 2>/dev/null || :
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir


### PR DESCRIPTION
If using --user, (non-root) the user wouldn't be able to chown.
Also, it creates $PGDATA as an arbitrary user(which would make that directory owned by that user), so it won't be needed anyways.