### PR TITLE
Allow args to be passed to Postgres during init

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -95,7 +95,7 @@ if [ "$1" = 'postgres' ]; then
 		# does not listen on external TCP/IP and waits until start finishes
 		PGUSER="${PGUSER:-postgres}" \
 		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses='localhost'" \
+			-o "-c listen_addresses='localhost' $POSTGRES_INIT_ARGS" \
 			-w start
 
 		file_env 'POSTGRES_USER' 'postgres'


### PR DESCRIPTION
..sometimes it's desirable to pass additional arguments to Postgres when it's started for the init scripts

This change allows those to be given by setting a POSTGRES_INIT_ARGS environment variable