### PR TITLE
Add POSTGRES_DB_TEST variable

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -110,6 +110,13 @@ if [ "$1" = 'postgres' ]; then
 			echo
 		fi
 
+		if [ "$POSTGRES_DB_TEST" ]; then
+			"${psql[@]}" --username postgres <<-EOSQL
+				CREATE DATABASE "${POSTGRES_DB}_test" ;
+			EOSQL
+			echo
+		fi
+
 		if [ "$POSTGRES_USER" = 'postgres' ]; then
 			op='ALTER'
 		else


### PR DESCRIPTION
If this optional environment variable is set, test database will be created. Resulting name of the test database is a join of default database name and "_test" suffix.
