### PR TITLE
Support of languages and fix

### DIFF
--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -28,10 +28,11 @@ RUN set -x \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
 
+ENV LANG en_US.utf8
+ENV LANGUAGE en_US
 # make the "en_US.UTF-8" locale so postgres will be utf-8 enabled by default
 RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
-	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-ENV LANG en_US.utf8
+	&& localedef -i $LANGUAGE -c -f UTF-8 -A /usr/share/locale/locale.alias $LANG
 
 RUN mkdir /docker-entrypoint-initdb.d
 

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+localedef -i $LANGUAGE -c -f UTF-8 -A /usr/share/locale/locale.alias $LANG
+
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
 # (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-localedef -i $LANGUAGE -c -f UTF-8 -A /usr/share/locale/locale.alias $LANG
-
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
 # (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
@@ -46,6 +44,7 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 		chmod 700 "$POSTGRES_INITDB_XLOGDIR"
 	fi
 
+	localedef -i $LANGUAGE -c -f UTF-8 -A /usr/share/locale/locale.alias $LANG
 	exec gosu postgres "$BASH_SOURCE" "$@"
 fi
 


### PR DESCRIPTION
Hi!

I need to be able to change the language of the database. Can this be a good change?

**Default mode**

`docker run -e POSTGRES_USER=example -e POSTGRES_PASSWORD=pass tedezed/postgres:9.6`

```
postgres=# SHOW LC_COLLATE;
 lc_collate 
------------
 en_US.utf8
```
**Change language**

`docker run -e POSTGRES_USER=exaple -e POSTGRES_PASSWORD=pass -e LANG="ja_JP.utf8" -e LANGUAGE="ja_JP" tedezed/postgres:9.6`

```
postgres=# SHOW LC_COLLATE;
 lc_collate 
------------
 ja_JP.utf8
(1 fila)
```

Log:
```
データベースシステム内のファイルの所有者は"postgres"ユーザでした。
このユーザがサーバプロセスを所有しなければなりません。

データベースクラスタはロケール"ja_JP.utf8"で初期化されます。
したがってデフォルトのデータベース符号化方式はUTF8に設定されました。
initdb: ロケール"ja_JP.utf8"用の適切なテキスト検索設定が見つかりません
デフォルトのテキスト検索設定はsimpleに設定されました。

データベージのチェックサムは無効です。

ディレクトリ/var/lib/postgresql/dataの権限を設定しています ... ok
サブディレクトリを作成しています ... ok
デフォルトのmax_connectionsを選択しています ... 100
デフォルトの shared_buffers を選択しています ... 128MB
selecting dynamic shared memory implementation ... posix
設定ファイルを作成しています ... ok
running bootstrap script ... ok
performing post-bootstrap initialization ... ok
データをディスクに同期しています...ok

Success. You can now start the database server using:

    pg_ctl -D /var/lib/postgresql/data -l logfile start


警告: ローカル接続向けに"trust"認証が有効です。
pg_hba.confを編集する、もしくは、次回initdbを実行する時に-Aオプショ
ン、または、--auth-localおよび--auth-hostを使用することで変更するこ
とができます。
サーバの起動完了を待っています....LOG:  IPv6ソケットをバインドできませんでした: 要求アドレスに割り当てられません
ヒント:  すでに他にpostmasterがポート5432で稼動していませんか? 稼動していなければ数秒待ってから再実行してください
LOG:  データベースシステムは 2017-12-13 14:50:34 UTC にシャットダウンしました
LOG:  MultiXact member wraparound protections are now enabled
LOG:  データベースシステムの接続受付準備が整いました。
LOG:  自動バキュームランチャプロセス
完了
サーバ起動完了
CREATE DATABASE

CREATE ROLE


/usr/local/bin/docker-entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*

LOG:  高速シャットダウン要求を受け取りました
LOG:  活動中の全トランザクションをアボートしています
LOG:  自動バキュームランチャを停止しています
サーバ停止処理の完了を待っています....LOG:  シャットダウンしています
LOG:  データベースシステムはシャットダウンしました
完了
サーバは停止しました

PostgreSQL init process complete; ready for start up.

LOG:  データベースシステムは 2017-12-13 14:50:36 UTC にシャットダウンしました
LOG:  MultiXact member wraparound protections are now enabled
LOG:  データベースシステムの接続受付準備が整いました。
LOG:  自動バキュームランチャプロセス
```
Greetings and many thanks.