### PR TITLE
Allow pg_ctl to be used with docker-entrypoint.sh

### DIFF
--- a/10/docker-entrypoint.sh
+++ b/10/docker-entrypoint.sh
@@ -47,7 +47,7 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 	exec gosu postgres "$BASH_SOURCE" "$@"
 fi
 
-if [ "$1" = 'postgres' ]; then
+if [ "$1" = 'postgres' ] || [ "$1" = 'pg_ctl' ] ; then
 	mkdir -p "$PGDATA"
 	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
 	chmod 700 "$PGDATA" 2>/dev/null || :


### PR DESCRIPTION
I think it can be very useful to also be able to pass pg_ctl to docker-entrypoint.sh.
It allows to built neat immutable db images..
Also, since pg_ctl is the official way to manage postgres, it help making images compatible with a lot of custom toolchains.
I think the risk of regression is near null (don't we always? :P), but the reward worse those 22 characters :)