### PR TITLE
allow inputing non-ascii char with psql

### DIFF
--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -121,6 +121,9 @@ RUN mv -v "/usr/share/postgresql/$PG_MAJOR/postgresql.conf.sample" /usr/share/po
 
 RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
 
+# without this, it's not possible to input non-ascii character when launching psql from within the container
+ENV LD_PRELOAD=/lib/x86_64-linux-gnu/libreadline.so.6.3 
+
 ENV PATH $PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)


### PR DESCRIPTION
you can easily test this: 

try without,  then run 

 docker exec -it your_instance psql

versus 

 docker exec -it your_instance -c 'LD_PRELOAD=/lib/x86_64-linux-gnu/libreadline.so.6.3 TERM=xterm psql'

in one you can input non-ascii character (like french accent or cyrilics)  , in the other you can't