### PR TITLE
Listen only on the unix socket during init 

### DIFF
--- a/10/alpine/docker-entrypoint.sh
+++ b/10/alpine/docker-entrypoint.sh
@@ -95,7 +95,7 @@ if [ "$1" = 'postgres' ]; then
 		# does not listen on external TCP/IP and waits until start finishes
 		PGUSER="${PGUSER:-postgres}" \
 		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses='localhost'" \
+			-o "-c listen_addresses=''" \
 			-w start
 
 		file_env 'POSTGRES_USER' 'postgres'

--- a/10/docker-entrypoint.sh
+++ b/10/docker-entrypoint.sh
@@ -95,7 +95,7 @@ if [ "$1" = 'postgres' ]; then
 		# does not listen on external TCP/IP and waits until start finishes
 		PGUSER="${PGUSER:-postgres}" \
 		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses='localhost'" \
+			-o "-c listen_addresses=''" \
 			-w start
 
 		file_env 'POSTGRES_USER' 'postgres'

--- a/9.3/alpine/docker-entrypoint.sh
+++ b/9.3/alpine/docker-entrypoint.sh
@@ -95,7 +95,7 @@ if [ "$1" = 'postgres' ]; then
 		# does not listen on external TCP/IP and waits until start finishes
 		PGUSER="${PGUSER:-postgres}" \
 		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses='localhost'" \
+			-o "-c listen_addresses=''" \
 			-w start
 
 		file_env 'POSTGRES_USER' 'postgres'

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -95,7 +95,7 @@ if [ "$1" = 'postgres' ]; then
 		# does not listen on external TCP/IP and waits until start finishes
 		PGUSER="${PGUSER:-postgres}" \
 		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses='localhost'" \
+			-o "-c listen_addresses=''" \
 			-w start
 
 		file_env 'POSTGRES_USER' 'postgres'

--- a/9.4/alpine/docker-entrypoint.sh
+++ b/9.4/alpine/docker-entrypoint.sh
@@ -95,7 +95,7 @@ if [ "$1" = 'postgres' ]; then
 		# does not listen on external TCP/IP and waits until start finishes
 		PGUSER="${PGUSER:-postgres}" \
 		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses='localhost'" \
+			-o "-c listen_addresses=''" \
 			-w start
 
 		file_env 'POSTGRES_USER' 'postgres'

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -95,7 +95,7 @@ if [ "$1" = 'postgres' ]; then
 		# does not listen on external TCP/IP and waits until start finishes
 		PGUSER="${PGUSER:-postgres}" \
 		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses='localhost'" \
+			-o "-c listen_addresses=''" \
 			-w start
 
 		file_env 'POSTGRES_USER' 'postgres'

--- a/9.5/alpine/docker-entrypoint.sh
+++ b/9.5/alpine/docker-entrypoint.sh
@@ -95,7 +95,7 @@ if [ "$1" = 'postgres' ]; then
 		# does not listen on external TCP/IP and waits until start finishes
 		PGUSER="${PGUSER:-postgres}" \
 		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses='localhost'" \
+			-o "-c listen_addresses=''" \
 			-w start
 
 		file_env 'POSTGRES_USER' 'postgres'

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -95,7 +95,7 @@ if [ "$1" = 'postgres' ]; then
 		# does not listen on external TCP/IP and waits until start finishes
 		PGUSER="${PGUSER:-postgres}" \
 		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses='localhost'" \
+			-o "-c listen_addresses=''" \
 			-w start
 
 		file_env 'POSTGRES_USER' 'postgres'

--- a/9.6/alpine/docker-entrypoint.sh
+++ b/9.6/alpine/docker-entrypoint.sh
@@ -95,7 +95,7 @@ if [ "$1" = 'postgres' ]; then
 		# does not listen on external TCP/IP and waits until start finishes
 		PGUSER="${PGUSER:-postgres}" \
 		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses='localhost'" \
+			-o "-c listen_addresses=''" \
 			-w start
 
 		file_env 'POSTGRES_USER' 'postgres'

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -95,7 +95,7 @@ if [ "$1" = 'postgres' ]; then
 		# does not listen on external TCP/IP and waits until start finishes
 		PGUSER="${PGUSER:-postgres}" \
 		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses='localhost'" \
+			-o "-c listen_addresses=''" \
 			-w start
 
 		file_env 'POSTGRES_USER' 'postgres'


### PR DESCRIPTION
Healthchecks that used `pg_isready -p 5432` were incorrectly flagging
the container as being healthy during initialization phase since
healthchecks are being run inside the container itself, so
`listen_addresses='localhost'` was not enough. The port `65432` was
chosen at random.