### PR TITLE
Implement "nss_wrapper" for Debian variants

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -40,6 +40,14 @@ RUN set -eux; \
 	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+# install "nss_wrapper" in case we need to fake "/etc/passwd" and "/etc/group" (especially for OpenShift)
+# https://github.com/docker-library/postgres/issues/359
+# https://cwrap.org/nss_wrapper.html
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends libnss-wrapper; \
+	rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /docker-entrypoint-initdb.d
 
 RUN set -ex; \

--- a/10/alpine/docker-entrypoint.sh
+++ b/10/alpine/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -e
+set -Eeo pipefail
+# TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
 
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
@@ -54,11 +55,27 @@ if [ "$1" = 'postgres' ]; then
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
+		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+			export NSS_WRAPPER_PASSWD="$(mktemp)"
+			export NSS_WRAPPER_GROUP="$(mktemp)"
+			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+		fi
+
 		file_env 'POSTGRES_INITDB_ARGS'
 		if [ "$POSTGRES_INITDB_WALDIR" ]; then
 			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --waldir $POSTGRES_INITDB_WALDIR"
 		fi
 		eval "initdb --username=postgres $POSTGRES_INITDB_ARGS"
+
+		# unset/cleanup "nss_wrapper" bits
+		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+		fi
 
 		# check password first so we can output the warning before postgres
 		# messes it up

--- a/10/docker-entrypoint.sh
+++ b/10/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -e
+set -Eeo pipefail
+# TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
 
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
@@ -54,11 +55,27 @@ if [ "$1" = 'postgres' ]; then
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
+		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+			export NSS_WRAPPER_PASSWD="$(mktemp)"
+			export NSS_WRAPPER_GROUP="$(mktemp)"
+			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+		fi
+
 		file_env 'POSTGRES_INITDB_ARGS'
 		if [ "$POSTGRES_INITDB_WALDIR" ]; then
 			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --waldir $POSTGRES_INITDB_WALDIR"
 		fi
 		eval "initdb --username=postgres $POSTGRES_INITDB_ARGS"
+
+		# unset/cleanup "nss_wrapper" bits
+		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+		fi
 
 		# check password first so we can output the warning before postgres
 		# messes it up

--- a/9.3/Dockerfile
+++ b/9.3/Dockerfile
@@ -40,6 +40,14 @@ RUN set -eux; \
 	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+# install "nss_wrapper" in case we need to fake "/etc/passwd" and "/etc/group" (especially for OpenShift)
+# https://github.com/docker-library/postgres/issues/359
+# https://cwrap.org/nss_wrapper.html
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends libnss-wrapper; \
+	rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /docker-entrypoint-initdb.d
 
 RUN set -ex; \

--- a/9.3/alpine/docker-entrypoint.sh
+++ b/9.3/alpine/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -e
+set -Eeo pipefail
+# TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
 
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
@@ -54,11 +55,27 @@ if [ "$1" = 'postgres' ]; then
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
+		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+			export NSS_WRAPPER_PASSWD="$(mktemp)"
+			export NSS_WRAPPER_GROUP="$(mktemp)"
+			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+		fi
+
 		file_env 'POSTGRES_INITDB_ARGS'
 		if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
 			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --xlogdir $POSTGRES_INITDB_XLOGDIR"
 		fi
 		eval "initdb --username=postgres $POSTGRES_INITDB_ARGS"
+
+		# unset/cleanup "nss_wrapper" bits
+		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+		fi
 
 		# check password first so we can output the warning before postgres
 		# messes it up

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -e
+set -Eeo pipefail
+# TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
 
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
@@ -54,11 +55,27 @@ if [ "$1" = 'postgres' ]; then
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
+		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+			export NSS_WRAPPER_PASSWD="$(mktemp)"
+			export NSS_WRAPPER_GROUP="$(mktemp)"
+			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+		fi
+
 		file_env 'POSTGRES_INITDB_ARGS'
 		if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
 			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --xlogdir $POSTGRES_INITDB_XLOGDIR"
 		fi
 		eval "initdb --username=postgres $POSTGRES_INITDB_ARGS"
+
+		# unset/cleanup "nss_wrapper" bits
+		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+		fi
 
 		# check password first so we can output the warning before postgres
 		# messes it up

--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -40,6 +40,14 @@ RUN set -eux; \
 	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+# install "nss_wrapper" in case we need to fake "/etc/passwd" and "/etc/group" (especially for OpenShift)
+# https://github.com/docker-library/postgres/issues/359
+# https://cwrap.org/nss_wrapper.html
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends libnss-wrapper; \
+	rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /docker-entrypoint-initdb.d
 
 RUN set -ex; \

--- a/9.4/alpine/docker-entrypoint.sh
+++ b/9.4/alpine/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -e
+set -Eeo pipefail
+# TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
 
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
@@ -54,11 +55,27 @@ if [ "$1" = 'postgres' ]; then
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
+		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+			export NSS_WRAPPER_PASSWD="$(mktemp)"
+			export NSS_WRAPPER_GROUP="$(mktemp)"
+			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+		fi
+
 		file_env 'POSTGRES_INITDB_ARGS'
 		if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
 			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --xlogdir $POSTGRES_INITDB_XLOGDIR"
 		fi
 		eval "initdb --username=postgres $POSTGRES_INITDB_ARGS"
+
+		# unset/cleanup "nss_wrapper" bits
+		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+		fi
 
 		# check password first so we can output the warning before postgres
 		# messes it up

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -e
+set -Eeo pipefail
+# TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
 
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
@@ -54,11 +55,27 @@ if [ "$1" = 'postgres' ]; then
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
+		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+			export NSS_WRAPPER_PASSWD="$(mktemp)"
+			export NSS_WRAPPER_GROUP="$(mktemp)"
+			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+		fi
+
 		file_env 'POSTGRES_INITDB_ARGS'
 		if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
 			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --xlogdir $POSTGRES_INITDB_XLOGDIR"
 		fi
 		eval "initdb --username=postgres $POSTGRES_INITDB_ARGS"
+
+		# unset/cleanup "nss_wrapper" bits
+		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+		fi
 
 		# check password first so we can output the warning before postgres
 		# messes it up

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -40,6 +40,14 @@ RUN set -eux; \
 	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+# install "nss_wrapper" in case we need to fake "/etc/passwd" and "/etc/group" (especially for OpenShift)
+# https://github.com/docker-library/postgres/issues/359
+# https://cwrap.org/nss_wrapper.html
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends libnss-wrapper; \
+	rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /docker-entrypoint-initdb.d
 
 RUN set -ex; \

--- a/9.5/alpine/docker-entrypoint.sh
+++ b/9.5/alpine/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -e
+set -Eeo pipefail
+# TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
 
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
@@ -54,11 +55,27 @@ if [ "$1" = 'postgres' ]; then
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
+		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+			export NSS_WRAPPER_PASSWD="$(mktemp)"
+			export NSS_WRAPPER_GROUP="$(mktemp)"
+			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+		fi
+
 		file_env 'POSTGRES_INITDB_ARGS'
 		if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
 			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --xlogdir $POSTGRES_INITDB_XLOGDIR"
 		fi
 		eval "initdb --username=postgres $POSTGRES_INITDB_ARGS"
+
+		# unset/cleanup "nss_wrapper" bits
+		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+		fi
 
 		# check password first so we can output the warning before postgres
 		# messes it up

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -e
+set -Eeo pipefail
+# TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
 
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
@@ -54,11 +55,27 @@ if [ "$1" = 'postgres' ]; then
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
+		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+			export NSS_WRAPPER_PASSWD="$(mktemp)"
+			export NSS_WRAPPER_GROUP="$(mktemp)"
+			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+		fi
+
 		file_env 'POSTGRES_INITDB_ARGS'
 		if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
 			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --xlogdir $POSTGRES_INITDB_XLOGDIR"
 		fi
 		eval "initdb --username=postgres $POSTGRES_INITDB_ARGS"
+
+		# unset/cleanup "nss_wrapper" bits
+		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+		fi
 
 		# check password first so we can output the warning before postgres
 		# messes it up

--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -40,6 +40,14 @@ RUN set -eux; \
 	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+# install "nss_wrapper" in case we need to fake "/etc/passwd" and "/etc/group" (especially for OpenShift)
+# https://github.com/docker-library/postgres/issues/359
+# https://cwrap.org/nss_wrapper.html
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends libnss-wrapper; \
+	rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /docker-entrypoint-initdb.d
 
 RUN set -ex; \

--- a/9.6/alpine/docker-entrypoint.sh
+++ b/9.6/alpine/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -e
+set -Eeo pipefail
+# TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
 
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
@@ -54,11 +55,27 @@ if [ "$1" = 'postgres' ]; then
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
+		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+			export NSS_WRAPPER_PASSWD="$(mktemp)"
+			export NSS_WRAPPER_GROUP="$(mktemp)"
+			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+		fi
+
 		file_env 'POSTGRES_INITDB_ARGS'
 		if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
 			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --xlogdir $POSTGRES_INITDB_XLOGDIR"
 		fi
 		eval "initdb --username=postgres $POSTGRES_INITDB_ARGS"
+
+		# unset/cleanup "nss_wrapper" bits
+		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+		fi
 
 		# check password first so we can output the warning before postgres
 		# messes it up

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -e
+set -Eeo pipefail
+# TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
 
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
@@ -54,11 +55,27 @@ if [ "$1" = 'postgres' ]; then
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
+		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+			export NSS_WRAPPER_PASSWD="$(mktemp)"
+			export NSS_WRAPPER_GROUP="$(mktemp)"
+			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+		fi
+
 		file_env 'POSTGRES_INITDB_ARGS'
 		if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
 			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --xlogdir $POSTGRES_INITDB_XLOGDIR"
 		fi
 		eval "initdb --username=postgres $POSTGRES_INITDB_ARGS"
+
+		# unset/cleanup "nss_wrapper" bits
+		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+		fi
 
 		# check password first so we can output the warning before postgres
 		# messes it up

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -40,6 +40,14 @@ RUN set -eux; \
 	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+# install "nss_wrapper" in case we need to fake "/etc/passwd" and "/etc/group" (especially for OpenShift)
+# https://github.com/docker-library/postgres/issues/359
+# https://cwrap.org/nss_wrapper.html
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends libnss-wrapper; \
+	rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /docker-entrypoint-initdb.d
 
 RUN set -ex; \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -e
+set -Eeo pipefail
+# TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
 
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
@@ -54,11 +55,27 @@ if [ "$1" = 'postgres' ]; then
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then
+		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+			export NSS_WRAPPER_PASSWD="$(mktemp)"
+			export NSS_WRAPPER_GROUP="$(mktemp)"
+			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+		fi
+
 		file_env 'POSTGRES_INITDB_ARGS'
 		if [ "$POSTGRES_INITDB_WALDIR" ]; then
 			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --waldir $POSTGRES_INITDB_WALDIR"
 		fi
 		eval "initdb --username=postgres $POSTGRES_INITDB_ARGS"
+
+		# unset/cleanup "nss_wrapper" bits
+		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+		fi
 
 		# check password first so we can output the warning before postgres
 		# messes it up


### PR DESCRIPTION
Closes #359

```console
$ docker build 10
...
Successfully built 8808cf28be91

$ mkdir "$HOME/pgtemp"
$ sudo chown 1000:1000 "$HOME/pgtemp"

$ docker run -it --rm --user 1000:1000 -v "$HOME/pgtemp":/var/lib/postgresql/data 8808cf28be91
The files belonging to this database system will be owned by user "postgres".
This user must also own the server process.

The database cluster will be initialized with locale "en_US.utf8".
The default database encoding has accordingly been set to "UTF8".
The default text search configuration will be set to "english".

Data page checksums are disabled.

fixing permissions on existing directory /var/lib/postgresql/data ... ok
creating subdirectories ... ok
selecting default max_connections ... 100
selecting default shared_buffers ... 128MB
selecting dynamic shared memory implementation ... posix
creating configuration files ... ok
running bootstrap script ... ok
performing post-bootstrap initialization ... ok
syncing data to disk ... ok

WARNING: enabling "trust" authentication for local connections
You can change this by editing pg_hba.conf or using the option -A, or
--auth-local and --auth-host, the next time you run initdb.

Success. You can now start the database server using:

    pg_ctl -D /var/lib/postgresql/data -l logfile start

****************************************************
WARNING: No password has been set for the database.
         This will allow anyone with access to the
         Postgres port to access your database. In
         Docker's default configuration, this is
         effectively any other container on the same
         system.

         Use "-e POSTGRES_PASSWORD=password" to set
         it in "docker run".
****************************************************
waiting for server to start....2018-05-24 18:47:31.537 UTC [37] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2018-05-24 18:47:31.560 UTC [38] LOG:  database system was shut down at 2018-05-24 18:47:31 UTC
2018-05-24 18:47:31.565 UTC [37] LOG:  database system is ready to accept connections
 done
server started
ALTER ROLE


/usr/local/bin/docker-entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*

2018-05-24 18:47:31.655 UTC [37] LOG:  received fast shutdown request
waiting for server to shut down....2018-05-24 18:47:31.656 UTC [37] LOG:  aborting any active transactions
2018-05-24 18:47:31.657 UTC [37] LOG:  worker process: logical replication launcher (PID 44) exited with exit code 1
2018-05-24 18:47:31.657 UTC [39] LOG:  shutting down
2018-05-24 18:47:31.671 UTC [37] LOG:  database system is shut down
 done
server stopped

PostgreSQL init process complete; ready for start up.

2018-05-24 18:47:31.781 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2018-05-24 18:47:31.781 UTC [1] LOG:  listening on IPv6 address "::", port 5432
2018-05-24 18:47:31.785 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2018-05-24 18:47:31.810 UTC [55] LOG:  database system was shut down at 2018-05-24 18:47:31 UTC
2018-05-24 18:47:31.815 UTC [1] LOG:  database system is ready to accept connections
```