### PR TITLE
Allow for passing args for base image being used.

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -1,7 +1,7 @@
 # vim:set ft=dockerfile:
 ARG  REPOSITORY=alpine
 ARG  TAG=3.7
-FROM ${REPOSITORY}:${TAG}
+FROM $REPOSITORY:$TAG
 
 # alpine includes "postgres" user/group in base install
 #   /etc/passwd:22:postgres:x:70:70::/var/lib/postgresql:/bin/sh

--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -1,5 +1,7 @@
 # vim:set ft=dockerfile:
-FROM alpine:3.7
+ARG  REPOSITORY=alpine
+ARG  TAG=3.7
+FROM ${REPOSITORY}:${TAG}
 
 # alpine includes "postgres" user/group in base install
 #   /etc/passwd:22:postgres:x:70:70::/var/lib/postgresql:/bin/sh


### PR DESCRIPTION
We have a need/use-case to build the postgres alpine image off of the openjdk-alpine image for UDF/etc. This change would allow anyone to clone this dockerfile and build the image in much the same way you guys do just with a different base image.