### PR TITLE
run directory creation & permission change when PGDATA is a mountpoint

### DIFF
--- a/10/alpine/docker-entrypoint.sh
+++ b/10/alpine/docker-entrypoint.sh
@@ -30,9 +30,11 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
-	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
-	chmod 700 "$PGDATA"
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R postgres "$PGDATA"
+		chmod 700 "$PGDATA"
+	fi
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
@@ -49,9 +51,11 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 fi
 
 if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+		chmod 700 "$PGDATA" 2>/dev/null || :
+	fi
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then

--- a/10/docker-entrypoint.sh
+++ b/10/docker-entrypoint.sh
@@ -30,9 +30,11 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
-	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
-	chmod 700 "$PGDATA"
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R postgres "$PGDATA"
+		chmod 700 "$PGDATA"
+	fi
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
@@ -49,9 +51,11 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 fi
 
 if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+		chmod 700 "$PGDATA" 2>/dev/null || :
+	fi
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then

--- a/11/alpine/docker-entrypoint.sh
+++ b/11/alpine/docker-entrypoint.sh
@@ -30,9 +30,11 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
-	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
-	chmod 700 "$PGDATA"
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R postgres "$PGDATA"
+		chmod 700 "$PGDATA"
+	fi
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
@@ -49,9 +51,11 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 fi
 
 if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+		chmod 700 "$PGDATA" 2>/dev/null || :
+	fi
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then

--- a/11/docker-entrypoint.sh
+++ b/11/docker-entrypoint.sh
@@ -30,9 +30,11 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
-	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
-	chmod 700 "$PGDATA"
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R postgres "$PGDATA"
+		chmod 700 "$PGDATA"
+	fi
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
@@ -49,9 +51,11 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 fi
 
 if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+		chmod 700 "$PGDATA" 2>/dev/null || :
+	fi
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then

--- a/9.3/alpine/docker-entrypoint.sh
+++ b/9.3/alpine/docker-entrypoint.sh
@@ -30,9 +30,11 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
-	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
-	chmod 700 "$PGDATA"
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R postgres "$PGDATA"
+		chmod 700 "$PGDATA"
+	fi
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
@@ -49,9 +51,11 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 fi
 
 if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+		chmod 700 "$PGDATA" 2>/dev/null || :
+	fi
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -30,9 +30,11 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
-	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
-	chmod 700 "$PGDATA"
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R postgres "$PGDATA"
+		chmod 700 "$PGDATA"
+	fi
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
@@ -49,9 +51,11 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 fi
 
 if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+		chmod 700 "$PGDATA" 2>/dev/null || :
+	fi
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then

--- a/9.4/alpine/docker-entrypoint.sh
+++ b/9.4/alpine/docker-entrypoint.sh
@@ -30,9 +30,11 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
-	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
-	chmod 700 "$PGDATA"
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R postgres "$PGDATA"
+		chmod 700 "$PGDATA"
+	fi
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
@@ -49,9 +51,11 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 fi
 
 if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+		chmod 700 "$PGDATA" 2>/dev/null || :
+	fi
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -30,9 +30,11 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
-	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
-	chmod 700 "$PGDATA"
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R postgres "$PGDATA"
+		chmod 700 "$PGDATA"
+	fi
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
@@ -49,9 +51,11 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 fi
 
 if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+		chmod 700 "$PGDATA" 2>/dev/null || :
+	fi
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then

--- a/9.5/alpine/docker-entrypoint.sh
+++ b/9.5/alpine/docker-entrypoint.sh
@@ -30,9 +30,11 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
-	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
-	chmod 700 "$PGDATA"
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R postgres "$PGDATA"
+		chmod 700 "$PGDATA"
+	fi
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
@@ -49,9 +51,11 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 fi
 
 if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+		chmod 700 "$PGDATA" 2>/dev/null || :
+	fi
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -30,9 +30,11 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
-	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
-	chmod 700 "$PGDATA"
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R postgres "$PGDATA"
+		chmod 700 "$PGDATA"
+	fi
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
@@ -49,9 +51,11 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 fi
 
 if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+		chmod 700 "$PGDATA" 2>/dev/null || :
+	fi
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then

--- a/9.6/alpine/docker-entrypoint.sh
+++ b/9.6/alpine/docker-entrypoint.sh
@@ -30,9 +30,11 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
-	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
-	chmod 700 "$PGDATA"
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R postgres "$PGDATA"
+		chmod 700 "$PGDATA"
+	fi
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
@@ -49,9 +51,11 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 fi
 
 if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+		chmod 700 "$PGDATA" 2>/dev/null || :
+	fi
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -30,9 +30,11 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
-	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
-	chmod 700 "$PGDATA"
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R postgres "$PGDATA"
+		chmod 700 "$PGDATA"
+	fi
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
@@ -49,9 +51,11 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 fi
 
 if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+		chmod 700 "$PGDATA" 2>/dev/null || :
+	fi
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,9 +30,11 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
-	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
-	chmod 700 "$PGDATA"
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R postgres "$PGDATA"
+		chmod 700 "$PGDATA"
+	fi
 
 	mkdir -p /var/run/postgresql
 	chown -R postgres /var/run/postgresql
@@ -49,9 +51,11 @@ if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 fi
 
 if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+	if mountpoint $PGDATA; then
+		mkdir -p "$PGDATA"
+		chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+		chmod 700 "$PGDATA" 2>/dev/null || :
+	fi
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ ! -s "$PGDATA/PG_VERSION" ]; then


### PR DESCRIPTION
When using image with data persisted to the image, these operations take a lot of time and are not needed if the image was correctly created.

It's possible to override the entrypoint in the new image, but I think it might be a good idea to have this in the base image.

Signed-off-by: Minh-Quan TRAN <account@itscaro.me>