### PR TITLE
feat: only chown files within data folder without correct ownership

### DIFF
--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -138,7 +138,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgres
 
 ENV PATH $PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 ENV PGDATA /var/lib/postgresql/data
-RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
+RUN mkdir -p "$PGDATA" && find "$PGDATA" \! -user postgres -exec chown postgres {} \; && chmod 777 "$PGDATA" # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -31,7 +31,7 @@ fi
 # allow the container to be started with `--user`
 if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
+	find "$PGDATA" \! -user postgres -exec chown postgres {} \;
 	chmod 700 "$PGDATA"
 
 	mkdir -p /var/run/postgresql
@@ -50,7 +50,7 @@ fi
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
+	find "$PGDATA" \! -user "$(id -u)" -exec chown "$(id -u)" {} \; 2>/dev/null || :
 	chmod 700 "$PGDATA" 2>/dev/null || :
 
 	# look specifically for PG_VERSION, as it is expected in the DB dir


### PR DESCRIPTION
For an image already containing data this can be a huge time saver to
only change ownership where it's needed.