### PR TITLE
Functionalize the entrypoint to allow outside sourcing for extreme customizing of startup

### DIFF
--- a/10/alpine/docker-entrypoint.sh
+++ b/10/alpine/docker-entrypoint.sh
@@ -24,153 +24,254 @@ file_env() {
 	unset "$fileVar"
 }
 
-if [ "${1:0:1}" = '-' ]; then
-	set -- postgres "$@"
-fi
+# check to see if this file is being run or sourced from another script
+_is_sourced() {
+	# https://unix.stackexchange.com/a/215279
+	[ "${#FUNCNAME[@]}" -ge 2 ] \
+		&& [ "${FUNCNAME[0]}" = '_is_sourced' ] \
+		&& [ "${FUNCNAME[1]}" = 'source' ]
+}
 
-# allow the container to be started with `--user`
-if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
+# used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
+docker_create_db_directories() {
+	local user="$(id -u)"
+
 	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
 
-	mkdir -p /var/run/postgresql
-	chown -R postgres /var/run/postgresql
-	chmod 775 /var/run/postgresql
+	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
+	mkdir -p /var/run/postgresql || :
+	chmod 775 /var/run/postgresql || :
 
-	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
+	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
-		chown -R postgres "$POSTGRES_INITDB_WALDIR"
+		[ "$user" = '0' ] && find "$POSTGRES_INITDB_WALDIR" \! -user postgres - exec chown postgres '{}' +
 		chmod 700 "$POSTGRES_INITDB_WALDIR"
 	fi
 
-	exec su-exec postgres "$BASH_SOURCE" "$@"
-fi
+	# allow the container to be started with `--user`
+	if [ "$user" = '0' ]; then
+		find "$PGDATA" \! -user postgres -exec chown postgres '{}' +
+		find /var/run/postgresql \! -user postgres -exec chown postgres '{}' +
+	fi
+}
 
-if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+# initialize empty PGDATA directory with new database via 'initdb'
+# arguments to `initdb` can be passed via POSTGRES_INITDB_ARGS or as arguments to this function
+# `initdb` automatically creates the "postgres", "template0", and "template1" dbnames
+# this is also where the database user is created, specified by `POSTGRES_USER` env
+docker_init_database_dir() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
 
-	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ ! -s "$PGDATA/PG_VERSION" ]; then
-		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
-		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
-		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
-			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
-			export NSS_WRAPPER_PASSWD="$(mktemp)"
-			export NSS_WRAPPER_GROUP="$(mktemp)"
-			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
-			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
-		fi
+	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
+	fi
 
-		file_env 'POSTGRES_USER' 'postgres'
-		file_env 'POSTGRES_PASSWORD'
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
 
-		file_env 'POSTGRES_INITDB_ARGS'
-		if [ "$POSTGRES_INITDB_WALDIR" ]; then
-			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --waldir $POSTGRES_INITDB_WALDIR"
-		fi
-		eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
 
-		# unset/cleanup "nss_wrapper" bits
-		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
-			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
-			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
-		fi
+# print large warning if POSTGRES_PASSWORD is empty
+docker_verify_minimum_env() {
+	# check password first so we can output the warning before postgres
+	# messes it up
+	if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
+		cat >&2 <<-'EOWARN'
 
-		# check password first so we can output the warning before postgres
-		# messes it up
-		if [ -n "$POSTGRES_PASSWORD" ]; then
-			authMethod=md5
+			WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
 
-			if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
-				cat >&2 <<-'EOWARN'
+			  This will not work if used via PGPASSWORD with "psql".
 
-					WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
+			  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
+			  https://github.com/docker-library/postgres/issues/507
 
-					  This will not work if used via PGPASSWORD with "psql".
+		EOWARN
+	fi
+	if [ -z "$POSTGRES_PASSWORD" ]; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+			****************************************************
+			WARNING: No password has been set for the database.
+			         This will allow anyone with access to the
+			         Postgres port to access your database. In
+			         Docker's default configuration, this is
+			         effectively any other container on the same
+			         system.
 
-					  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
-					  https://github.com/docker-library/postgres/issues/507
+			         Use "-e POSTGRES_PASSWORD=password" to set
+			         it in "docker run".
+			****************************************************
+		EOWARN
 
-				EOWARN
-			fi
-		else
-			# The - option suppresses leading tabs but *not* spaces. :)
-			cat >&2 <<-'EOWARN'
-				****************************************************
-				WARNING: No password has been set for the database.
-				         This will allow anyone with access to the
-				         Postgres port to access your database. In
-				         Docker's default configuration, this is
-				         effectively any other container on the same
-				         system.
+	fi
+}
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
-				****************************************************
-			EOWARN
+# usage: docker_process_init_files [file [file [...]]]
+#    ie: docker_process_init_files /always-initdb.d/*
+# process initializer files, based on file extensions and permissions
+docker_process_init_files() {
+	# psql here for backwards compatiblilty "${psql[@]}"
+	psql=( docker_process_sql )
 
-			authMethod=trust
-		fi
-
-		{
-			echo
-			echo "host all all all $authMethod"
-		} >> "$PGDATA/pg_hba.conf"
-
-		# internal start of server in order to allow set-up using psql-client
-		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
-
-		file_env 'POSTGRES_DB' "$POSTGRES_USER"
-
-		export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
-		psql=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
-
-		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			"${psql[@]}" --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
-				CREATE DATABASE :"db" ;
-			EOSQL
-			echo
-		fi
-		psql+=( --dbname "$POSTGRES_DB" )
-
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					echo "$0: running $f"
+					"$f"
+				else
+					echo "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
+			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*)        echo "$0: ignoring $f" ;;
+		esac
 		echo
-		for f in /docker-entrypoint-initdb.d/*; do
-			case "$f" in
-				*.sh)
-					# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
-					# https://github.com/docker-library/postgres/pull/452
-					if [ -x "$f" ]; then
-						echo "$0: running $f"
-						"$f"
-					else
-						echo "$0: sourcing $f"
-						. "$f"
-					fi
-					;;
-				*.sql)    echo "$0: running $f"; "${psql[@]}" -f "$f"; echo ;;
-				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${psql[@]}"; echo ;;
-				*)        echo "$0: ignoring $f" ;;
-			esac
-			echo
-		done
+	done
+}
 
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" -m fast -w stop
+# Execute sql script, passed via stdin (or -f flag of pqsl)
+# usage: docker_process_sql [psql-cli-args]
+#    ie: docker_process_sql --dbname=mydb <<<'INSERT ...'
+#    ie: docker_process_sql -f my-file.sql
+#    ie: docker_process_sql <my-file.sql
+docker_process_sql() {
+	local query_runner=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
+	if [ -n "$POSTGRES_DB" ]; then
+		query_runner+=( --dbname "$POSTGRES_DB" )
+	fi
 
-		unset PGPASSWORD
+	"${query_runner[@]}" "$@"
+}
 
-		echo
-		echo 'PostgreSQL init process complete; ready for start up.'
+# create initial database
+# uses environment variables for input: POSTGRES_DB
+docker_setup_db() {
+	if [ "$POSTGRES_DB" != 'postgres' ]; then
+		POSTGRES_DB= docker_process_sql --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
+			CREATE DATABASE :"db" ;
+		EOSQL
 		echo
 	fi
-fi
+}
 
-exec "$@"
+# Loads various settings that are used elsewhere in the script
+# This should be called before any other functions
+docker_setup_env() {
+	file_env 'POSTGRES_PASSWORD'
+
+	file_env 'POSTGRES_USER' 'postgres'
+	file_env 'POSTGRES_DB' "$POSTGRES_USER"
+	file_env 'POSTGRES_INITDB_ARGS'
+
+	declare -g DATABASE_ALREADY_EXISTS
+	# look specifically for PG_VERSION, as it is expected in the DB dir
+	if [ -s "$PGDATA/PG_VERSION" ]; then
+		DATABASE_ALREADY_EXISTS='true'
+	fi
+}
+
+# append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
+pg_setup_hba_conf() {
+	local authMethod
+	if [ "$POSTGRES_PASSWORD" ]; then
+		authMethod='md5'
+	else
+		authMethod='trust'
+	fi
+
+	{
+		echo
+		echo "host all all all $authMethod"
+	} >> "$PGDATA/pg_hba.conf"
+}
+
+# start socket-only postgresql server for setting up or running scripts
+# all arguments will be passed along as arguments to `postgres` (via pg_ctl)
+docker_temp_server_start() {
+	if [ "$1" = 'postgres' ]; then
+		shift
+	fi
+	# internal start of server in order to allow setup using psql client
+	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-w start
+}
+
+# stop postgresql server after done setting up user and running scripts
+docker_temp_server_stop() {
+	PGUSER="${PGUSER:-postgres}" \
+	pg_ctl -D "$PGDATA" -m fast -w stop
+}
+
+_main() {
+	# if first arg looks like a flag, assume we want to run postgres server
+	if [ "${1:0:1}" = '-' ]; then
+		set -- postgres "$@"
+	fi
+
+
+	if [ "$1" = 'postgres' ]; then
+		docker_setup_env
+		# setup data directories and permissions (when run as root)
+		docker_create_db_directories
+		if [ "$(id -u)" = '0' ]; then
+			# then restart script as postgres user
+			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		# only run initialization on an empty data directory
+		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+			docker_verify_minimum_env
+			docker_init_database_dir
+			pg_setup_hba_conf
+
+			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+			# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+			export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+			docker_temp_server_start "$@"
+
+			docker_setup_db
+			docker_process_init_files /docker-entrypoint-initdb.d/*
+
+			docker_temp_server_stop
+			unset PGPASSWORD
+
+			echo
+			echo 'PostgreSQL init process complete; ready for start up.'
+			echo
+		else
+			echo
+			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
+			echo
+		fi
+	fi
+
+	exec "$@"
+}
+
+if ! _is_sourced; then
+	_main "$@"
+fi

--- a/10/alpine/docker-entrypoint.sh
+++ b/10/alpine/docker-entrypoint.sh
@@ -34,7 +34,7 @@ _is_sourced() {
 
 # used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
 docker_create_db_directories() {
-	local user="$(id -u)"
+	local user; user="$(id -u)"
 
 	mkdir -p "$PGDATA"
 	chmod 700 "$PGDATA"
@@ -46,7 +46,9 @@ docker_create_db_directories() {
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
-		[ "$user" = '0' ] && find "$POSTGRES_INITDB_WALDIR" \! -user postgres - exec chown postgres '{}' +
+		if [ "$user" = '0' ]; then
+			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
+		fi
 		chmod 700 "$POSTGRES_INITDB_WALDIR"
 	fi
 
@@ -193,10 +195,8 @@ docker_setup_env() {
 
 # append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
 pg_setup_hba_conf() {
-	local authMethod
-	if [ "$POSTGRES_PASSWORD" ]; then
-		authMethod='md5'
-	else
+	local authMethod='md5'
+	if [ -z "$POSTGRES_PASSWORD" ]; then
 		authMethod='trust'
 	fi
 
@@ -231,7 +231,6 @@ _main() {
 	if [ "${1:0:1}" = '-' ]; then
 		set -- postgres "$@"
 	fi
-
 
 	if [ "$1" = 'postgres' ]; then
 		docker_setup_env

--- a/10/docker-entrypoint.sh
+++ b/10/docker-entrypoint.sh
@@ -24,153 +24,254 @@ file_env() {
 	unset "$fileVar"
 }
 
-if [ "${1:0:1}" = '-' ]; then
-	set -- postgres "$@"
-fi
+# check to see if this file is being run or sourced from another script
+_is_sourced() {
+	# https://unix.stackexchange.com/a/215279
+	[ "${#FUNCNAME[@]}" -ge 2 ] \
+		&& [ "${FUNCNAME[0]}" = '_is_sourced' ] \
+		&& [ "${FUNCNAME[1]}" = 'source' ]
+}
 
-# allow the container to be started with `--user`
-if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
+# used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
+docker_create_db_directories() {
+	local user="$(id -u)"
+
 	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
 
-	mkdir -p /var/run/postgresql
-	chown -R postgres /var/run/postgresql
-	chmod 775 /var/run/postgresql
+	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
+	mkdir -p /var/run/postgresql || :
+	chmod 775 /var/run/postgresql || :
 
-	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
+	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
-		chown -R postgres "$POSTGRES_INITDB_WALDIR"
+		[ "$user" = '0' ] && find "$POSTGRES_INITDB_WALDIR" \! -user postgres - exec chown postgres '{}' +
 		chmod 700 "$POSTGRES_INITDB_WALDIR"
 	fi
 
-	exec gosu postgres "$BASH_SOURCE" "$@"
-fi
+	# allow the container to be started with `--user`
+	if [ "$user" = '0' ]; then
+		find "$PGDATA" \! -user postgres -exec chown postgres '{}' +
+		find /var/run/postgresql \! -user postgres -exec chown postgres '{}' +
+	fi
+}
 
-if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+# initialize empty PGDATA directory with new database via 'initdb'
+# arguments to `initdb` can be passed via POSTGRES_INITDB_ARGS or as arguments to this function
+# `initdb` automatically creates the "postgres", "template0", and "template1" dbnames
+# this is also where the database user is created, specified by `POSTGRES_USER` env
+docker_init_database_dir() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
 
-	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ ! -s "$PGDATA/PG_VERSION" ]; then
-		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
-		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
-		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
-			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
-			export NSS_WRAPPER_PASSWD="$(mktemp)"
-			export NSS_WRAPPER_GROUP="$(mktemp)"
-			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
-			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
-		fi
+	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
+	fi
 
-		file_env 'POSTGRES_USER' 'postgres'
-		file_env 'POSTGRES_PASSWORD'
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
 
-		file_env 'POSTGRES_INITDB_ARGS'
-		if [ "$POSTGRES_INITDB_WALDIR" ]; then
-			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --waldir $POSTGRES_INITDB_WALDIR"
-		fi
-		eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
 
-		# unset/cleanup "nss_wrapper" bits
-		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
-			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
-			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
-		fi
+# print large warning if POSTGRES_PASSWORD is empty
+docker_verify_minimum_env() {
+	# check password first so we can output the warning before postgres
+	# messes it up
+	if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
+		cat >&2 <<-'EOWARN'
 
-		# check password first so we can output the warning before postgres
-		# messes it up
-		if [ -n "$POSTGRES_PASSWORD" ]; then
-			authMethod=md5
+			WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
 
-			if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
-				cat >&2 <<-'EOWARN'
+			  This will not work if used via PGPASSWORD with "psql".
 
-					WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
+			  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
+			  https://github.com/docker-library/postgres/issues/507
 
-					  This will not work if used via PGPASSWORD with "psql".
+		EOWARN
+	fi
+	if [ -z "$POSTGRES_PASSWORD" ]; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+			****************************************************
+			WARNING: No password has been set for the database.
+			         This will allow anyone with access to the
+			         Postgres port to access your database. In
+			         Docker's default configuration, this is
+			         effectively any other container on the same
+			         system.
 
-					  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
-					  https://github.com/docker-library/postgres/issues/507
+			         Use "-e POSTGRES_PASSWORD=password" to set
+			         it in "docker run".
+			****************************************************
+		EOWARN
 
-				EOWARN
-			fi
-		else
-			# The - option suppresses leading tabs but *not* spaces. :)
-			cat >&2 <<-'EOWARN'
-				****************************************************
-				WARNING: No password has been set for the database.
-				         This will allow anyone with access to the
-				         Postgres port to access your database. In
-				         Docker's default configuration, this is
-				         effectively any other container on the same
-				         system.
+	fi
+}
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
-				****************************************************
-			EOWARN
+# usage: docker_process_init_files [file [file [...]]]
+#    ie: docker_process_init_files /always-initdb.d/*
+# process initializer files, based on file extensions and permissions
+docker_process_init_files() {
+	# psql here for backwards compatiblilty "${psql[@]}"
+	psql=( docker_process_sql )
 
-			authMethod=trust
-		fi
-
-		{
-			echo
-			echo "host all all all $authMethod"
-		} >> "$PGDATA/pg_hba.conf"
-
-		# internal start of server in order to allow set-up using psql-client
-		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
-
-		file_env 'POSTGRES_DB' "$POSTGRES_USER"
-
-		export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
-		psql=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
-
-		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			"${psql[@]}" --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
-				CREATE DATABASE :"db" ;
-			EOSQL
-			echo
-		fi
-		psql+=( --dbname "$POSTGRES_DB" )
-
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					echo "$0: running $f"
+					"$f"
+				else
+					echo "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
+			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*)        echo "$0: ignoring $f" ;;
+		esac
 		echo
-		for f in /docker-entrypoint-initdb.d/*; do
-			case "$f" in
-				*.sh)
-					# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
-					# https://github.com/docker-library/postgres/pull/452
-					if [ -x "$f" ]; then
-						echo "$0: running $f"
-						"$f"
-					else
-						echo "$0: sourcing $f"
-						. "$f"
-					fi
-					;;
-				*.sql)    echo "$0: running $f"; "${psql[@]}" -f "$f"; echo ;;
-				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${psql[@]}"; echo ;;
-				*)        echo "$0: ignoring $f" ;;
-			esac
-			echo
-		done
+	done
+}
 
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" -m fast -w stop
+# Execute sql script, passed via stdin (or -f flag of pqsl)
+# usage: docker_process_sql [psql-cli-args]
+#    ie: docker_process_sql --dbname=mydb <<<'INSERT ...'
+#    ie: docker_process_sql -f my-file.sql
+#    ie: docker_process_sql <my-file.sql
+docker_process_sql() {
+	local query_runner=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
+	if [ -n "$POSTGRES_DB" ]; then
+		query_runner+=( --dbname "$POSTGRES_DB" )
+	fi
 
-		unset PGPASSWORD
+	"${query_runner[@]}" "$@"
+}
 
-		echo
-		echo 'PostgreSQL init process complete; ready for start up.'
+# create initial database
+# uses environment variables for input: POSTGRES_DB
+docker_setup_db() {
+	if [ "$POSTGRES_DB" != 'postgres' ]; then
+		POSTGRES_DB= docker_process_sql --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
+			CREATE DATABASE :"db" ;
+		EOSQL
 		echo
 	fi
-fi
+}
 
-exec "$@"
+# Loads various settings that are used elsewhere in the script
+# This should be called before any other functions
+docker_setup_env() {
+	file_env 'POSTGRES_PASSWORD'
+
+	file_env 'POSTGRES_USER' 'postgres'
+	file_env 'POSTGRES_DB' "$POSTGRES_USER"
+	file_env 'POSTGRES_INITDB_ARGS'
+
+	declare -g DATABASE_ALREADY_EXISTS
+	# look specifically for PG_VERSION, as it is expected in the DB dir
+	if [ -s "$PGDATA/PG_VERSION" ]; then
+		DATABASE_ALREADY_EXISTS='true'
+	fi
+}
+
+# append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
+pg_setup_hba_conf() {
+	local authMethod
+	if [ "$POSTGRES_PASSWORD" ]; then
+		authMethod='md5'
+	else
+		authMethod='trust'
+	fi
+
+	{
+		echo
+		echo "host all all all $authMethod"
+	} >> "$PGDATA/pg_hba.conf"
+}
+
+# start socket-only postgresql server for setting up or running scripts
+# all arguments will be passed along as arguments to `postgres` (via pg_ctl)
+docker_temp_server_start() {
+	if [ "$1" = 'postgres' ]; then
+		shift
+	fi
+	# internal start of server in order to allow setup using psql client
+	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-w start
+}
+
+# stop postgresql server after done setting up user and running scripts
+docker_temp_server_stop() {
+	PGUSER="${PGUSER:-postgres}" \
+	pg_ctl -D "$PGDATA" -m fast -w stop
+}
+
+_main() {
+	# if first arg looks like a flag, assume we want to run postgres server
+	if [ "${1:0:1}" = '-' ]; then
+		set -- postgres "$@"
+	fi
+
+
+	if [ "$1" = 'postgres' ]; then
+		docker_setup_env
+		# setup data directories and permissions (when run as root)
+		docker_create_db_directories
+		if [ "$(id -u)" = '0' ]; then
+			# then restart script as postgres user
+			exec gosu postgres "$BASH_SOURCE" "$@"
+		fi
+
+		# only run initialization on an empty data directory
+		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+			docker_verify_minimum_env
+			docker_init_database_dir
+			pg_setup_hba_conf
+
+			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+			# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+			export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+			docker_temp_server_start "$@"
+
+			docker_setup_db
+			docker_process_init_files /docker-entrypoint-initdb.d/*
+
+			docker_temp_server_stop
+			unset PGPASSWORD
+
+			echo
+			echo 'PostgreSQL init process complete; ready for start up.'
+			echo
+		else
+			echo
+			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
+			echo
+		fi
+	fi
+
+	exec "$@"
+}
+
+if ! _is_sourced; then
+	_main "$@"
+fi

--- a/10/docker-entrypoint.sh
+++ b/10/docker-entrypoint.sh
@@ -34,7 +34,7 @@ _is_sourced() {
 
 # used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
 docker_create_db_directories() {
-	local user="$(id -u)"
+	local user; user="$(id -u)"
 
 	mkdir -p "$PGDATA"
 	chmod 700 "$PGDATA"
@@ -46,7 +46,9 @@ docker_create_db_directories() {
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
-		[ "$user" = '0' ] && find "$POSTGRES_INITDB_WALDIR" \! -user postgres - exec chown postgres '{}' +
+		if [ "$user" = '0' ]; then
+			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
+		fi
 		chmod 700 "$POSTGRES_INITDB_WALDIR"
 	fi
 
@@ -193,10 +195,8 @@ docker_setup_env() {
 
 # append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
 pg_setup_hba_conf() {
-	local authMethod
-	if [ "$POSTGRES_PASSWORD" ]; then
-		authMethod='md5'
-	else
+	local authMethod='md5'
+	if [ -z "$POSTGRES_PASSWORD" ]; then
 		authMethod='trust'
 	fi
 
@@ -231,7 +231,6 @@ _main() {
 	if [ "${1:0:1}" = '-' ]; then
 		set -- postgres "$@"
 	fi
-
 
 	if [ "$1" = 'postgres' ]; then
 		docker_setup_env

--- a/11/alpine/docker-entrypoint.sh
+++ b/11/alpine/docker-entrypoint.sh
@@ -24,153 +24,254 @@ file_env() {
 	unset "$fileVar"
 }
 
-if [ "${1:0:1}" = '-' ]; then
-	set -- postgres "$@"
-fi
+# check to see if this file is being run or sourced from another script
+_is_sourced() {
+	# https://unix.stackexchange.com/a/215279
+	[ "${#FUNCNAME[@]}" -ge 2 ] \
+		&& [ "${FUNCNAME[0]}" = '_is_sourced' ] \
+		&& [ "${FUNCNAME[1]}" = 'source' ]
+}
 
-# allow the container to be started with `--user`
-if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
+# used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
+docker_create_db_directories() {
+	local user="$(id -u)"
+
 	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
 
-	mkdir -p /var/run/postgresql
-	chown -R postgres /var/run/postgresql
-	chmod 775 /var/run/postgresql
+	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
+	mkdir -p /var/run/postgresql || :
+	chmod 775 /var/run/postgresql || :
 
-	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
+	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
-		chown -R postgres "$POSTGRES_INITDB_WALDIR"
+		[ "$user" = '0' ] && find "$POSTGRES_INITDB_WALDIR" \! -user postgres - exec chown postgres '{}' +
 		chmod 700 "$POSTGRES_INITDB_WALDIR"
 	fi
 
-	exec su-exec postgres "$BASH_SOURCE" "$@"
-fi
+	# allow the container to be started with `--user`
+	if [ "$user" = '0' ]; then
+		find "$PGDATA" \! -user postgres -exec chown postgres '{}' +
+		find /var/run/postgresql \! -user postgres -exec chown postgres '{}' +
+	fi
+}
 
-if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+# initialize empty PGDATA directory with new database via 'initdb'
+# arguments to `initdb` can be passed via POSTGRES_INITDB_ARGS or as arguments to this function
+# `initdb` automatically creates the "postgres", "template0", and "template1" dbnames
+# this is also where the database user is created, specified by `POSTGRES_USER` env
+docker_init_database_dir() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
 
-	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ ! -s "$PGDATA/PG_VERSION" ]; then
-		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
-		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
-		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
-			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
-			export NSS_WRAPPER_PASSWD="$(mktemp)"
-			export NSS_WRAPPER_GROUP="$(mktemp)"
-			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
-			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
-		fi
+	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
+	fi
 
-		file_env 'POSTGRES_USER' 'postgres'
-		file_env 'POSTGRES_PASSWORD'
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
 
-		file_env 'POSTGRES_INITDB_ARGS'
-		if [ "$POSTGRES_INITDB_WALDIR" ]; then
-			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --waldir $POSTGRES_INITDB_WALDIR"
-		fi
-		eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
 
-		# unset/cleanup "nss_wrapper" bits
-		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
-			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
-			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
-		fi
+# print large warning if POSTGRES_PASSWORD is empty
+docker_verify_minimum_env() {
+	# check password first so we can output the warning before postgres
+	# messes it up
+	if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
+		cat >&2 <<-'EOWARN'
 
-		# check password first so we can output the warning before postgres
-		# messes it up
-		if [ -n "$POSTGRES_PASSWORD" ]; then
-			authMethod=md5
+			WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
 
-			if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
-				cat >&2 <<-'EOWARN'
+			  This will not work if used via PGPASSWORD with "psql".
 
-					WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
+			  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
+			  https://github.com/docker-library/postgres/issues/507
 
-					  This will not work if used via PGPASSWORD with "psql".
+		EOWARN
+	fi
+	if [ -z "$POSTGRES_PASSWORD" ]; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+			****************************************************
+			WARNING: No password has been set for the database.
+			         This will allow anyone with access to the
+			         Postgres port to access your database. In
+			         Docker's default configuration, this is
+			         effectively any other container on the same
+			         system.
 
-					  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
-					  https://github.com/docker-library/postgres/issues/507
+			         Use "-e POSTGRES_PASSWORD=password" to set
+			         it in "docker run".
+			****************************************************
+		EOWARN
 
-				EOWARN
-			fi
-		else
-			# The - option suppresses leading tabs but *not* spaces. :)
-			cat >&2 <<-'EOWARN'
-				****************************************************
-				WARNING: No password has been set for the database.
-				         This will allow anyone with access to the
-				         Postgres port to access your database. In
-				         Docker's default configuration, this is
-				         effectively any other container on the same
-				         system.
+	fi
+}
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
-				****************************************************
-			EOWARN
+# usage: docker_process_init_files [file [file [...]]]
+#    ie: docker_process_init_files /always-initdb.d/*
+# process initializer files, based on file extensions and permissions
+docker_process_init_files() {
+	# psql here for backwards compatiblilty "${psql[@]}"
+	psql=( docker_process_sql )
 
-			authMethod=trust
-		fi
-
-		{
-			echo
-			echo "host all all all $authMethod"
-		} >> "$PGDATA/pg_hba.conf"
-
-		# internal start of server in order to allow set-up using psql-client
-		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
-
-		file_env 'POSTGRES_DB' "$POSTGRES_USER"
-
-		export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
-		psql=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
-
-		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			"${psql[@]}" --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
-				CREATE DATABASE :"db" ;
-			EOSQL
-			echo
-		fi
-		psql+=( --dbname "$POSTGRES_DB" )
-
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					echo "$0: running $f"
+					"$f"
+				else
+					echo "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
+			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*)        echo "$0: ignoring $f" ;;
+		esac
 		echo
-		for f in /docker-entrypoint-initdb.d/*; do
-			case "$f" in
-				*.sh)
-					# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
-					# https://github.com/docker-library/postgres/pull/452
-					if [ -x "$f" ]; then
-						echo "$0: running $f"
-						"$f"
-					else
-						echo "$0: sourcing $f"
-						. "$f"
-					fi
-					;;
-				*.sql)    echo "$0: running $f"; "${psql[@]}" -f "$f"; echo ;;
-				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${psql[@]}"; echo ;;
-				*)        echo "$0: ignoring $f" ;;
-			esac
-			echo
-		done
+	done
+}
 
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" -m fast -w stop
+# Execute sql script, passed via stdin (or -f flag of pqsl)
+# usage: docker_process_sql [psql-cli-args]
+#    ie: docker_process_sql --dbname=mydb <<<'INSERT ...'
+#    ie: docker_process_sql -f my-file.sql
+#    ie: docker_process_sql <my-file.sql
+docker_process_sql() {
+	local query_runner=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
+	if [ -n "$POSTGRES_DB" ]; then
+		query_runner+=( --dbname "$POSTGRES_DB" )
+	fi
 
-		unset PGPASSWORD
+	"${query_runner[@]}" "$@"
+}
 
-		echo
-		echo 'PostgreSQL init process complete; ready for start up.'
+# create initial database
+# uses environment variables for input: POSTGRES_DB
+docker_setup_db() {
+	if [ "$POSTGRES_DB" != 'postgres' ]; then
+		POSTGRES_DB= docker_process_sql --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
+			CREATE DATABASE :"db" ;
+		EOSQL
 		echo
 	fi
-fi
+}
 
-exec "$@"
+# Loads various settings that are used elsewhere in the script
+# This should be called before any other functions
+docker_setup_env() {
+	file_env 'POSTGRES_PASSWORD'
+
+	file_env 'POSTGRES_USER' 'postgres'
+	file_env 'POSTGRES_DB' "$POSTGRES_USER"
+	file_env 'POSTGRES_INITDB_ARGS'
+
+	declare -g DATABASE_ALREADY_EXISTS
+	# look specifically for PG_VERSION, as it is expected in the DB dir
+	if [ -s "$PGDATA/PG_VERSION" ]; then
+		DATABASE_ALREADY_EXISTS='true'
+	fi
+}
+
+# append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
+pg_setup_hba_conf() {
+	local authMethod
+	if [ "$POSTGRES_PASSWORD" ]; then
+		authMethod='md5'
+	else
+		authMethod='trust'
+	fi
+
+	{
+		echo
+		echo "host all all all $authMethod"
+	} >> "$PGDATA/pg_hba.conf"
+}
+
+# start socket-only postgresql server for setting up or running scripts
+# all arguments will be passed along as arguments to `postgres` (via pg_ctl)
+docker_temp_server_start() {
+	if [ "$1" = 'postgres' ]; then
+		shift
+	fi
+	# internal start of server in order to allow setup using psql client
+	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-w start
+}
+
+# stop postgresql server after done setting up user and running scripts
+docker_temp_server_stop() {
+	PGUSER="${PGUSER:-postgres}" \
+	pg_ctl -D "$PGDATA" -m fast -w stop
+}
+
+_main() {
+	# if first arg looks like a flag, assume we want to run postgres server
+	if [ "${1:0:1}" = '-' ]; then
+		set -- postgres "$@"
+	fi
+
+
+	if [ "$1" = 'postgres' ]; then
+		docker_setup_env
+		# setup data directories and permissions (when run as root)
+		docker_create_db_directories
+		if [ "$(id -u)" = '0' ]; then
+			# then restart script as postgres user
+			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		# only run initialization on an empty data directory
+		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+			docker_verify_minimum_env
+			docker_init_database_dir
+			pg_setup_hba_conf
+
+			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+			# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+			export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+			docker_temp_server_start "$@"
+
+			docker_setup_db
+			docker_process_init_files /docker-entrypoint-initdb.d/*
+
+			docker_temp_server_stop
+			unset PGPASSWORD
+
+			echo
+			echo 'PostgreSQL init process complete; ready for start up.'
+			echo
+		else
+			echo
+			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
+			echo
+		fi
+	fi
+
+	exec "$@"
+}
+
+if ! _is_sourced; then
+	_main "$@"
+fi

--- a/11/alpine/docker-entrypoint.sh
+++ b/11/alpine/docker-entrypoint.sh
@@ -34,7 +34,7 @@ _is_sourced() {
 
 # used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
 docker_create_db_directories() {
-	local user="$(id -u)"
+	local user; user="$(id -u)"
 
 	mkdir -p "$PGDATA"
 	chmod 700 "$PGDATA"
@@ -46,7 +46,9 @@ docker_create_db_directories() {
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
-		[ "$user" = '0' ] && find "$POSTGRES_INITDB_WALDIR" \! -user postgres - exec chown postgres '{}' +
+		if [ "$user" = '0' ]; then
+			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
+		fi
 		chmod 700 "$POSTGRES_INITDB_WALDIR"
 	fi
 
@@ -193,10 +195,8 @@ docker_setup_env() {
 
 # append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
 pg_setup_hba_conf() {
-	local authMethod
-	if [ "$POSTGRES_PASSWORD" ]; then
-		authMethod='md5'
-	else
+	local authMethod='md5'
+	if [ -z "$POSTGRES_PASSWORD" ]; then
 		authMethod='trust'
 	fi
 
@@ -231,7 +231,6 @@ _main() {
 	if [ "${1:0:1}" = '-' ]; then
 		set -- postgres "$@"
 	fi
-
 
 	if [ "$1" = 'postgres' ]; then
 		docker_setup_env

--- a/11/docker-entrypoint.sh
+++ b/11/docker-entrypoint.sh
@@ -24,153 +24,254 @@ file_env() {
 	unset "$fileVar"
 }
 
-if [ "${1:0:1}" = '-' ]; then
-	set -- postgres "$@"
-fi
+# check to see if this file is being run or sourced from another script
+_is_sourced() {
+	# https://unix.stackexchange.com/a/215279
+	[ "${#FUNCNAME[@]}" -ge 2 ] \
+		&& [ "${FUNCNAME[0]}" = '_is_sourced' ] \
+		&& [ "${FUNCNAME[1]}" = 'source' ]
+}
 
-# allow the container to be started with `--user`
-if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
+# used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
+docker_create_db_directories() {
+	local user="$(id -u)"
+
 	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
 
-	mkdir -p /var/run/postgresql
-	chown -R postgres /var/run/postgresql
-	chmod 775 /var/run/postgresql
+	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
+	mkdir -p /var/run/postgresql || :
+	chmod 775 /var/run/postgresql || :
 
-	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
+	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
-		chown -R postgres "$POSTGRES_INITDB_WALDIR"
+		[ "$user" = '0' ] && find "$POSTGRES_INITDB_WALDIR" \! -user postgres - exec chown postgres '{}' +
 		chmod 700 "$POSTGRES_INITDB_WALDIR"
 	fi
 
-	exec gosu postgres "$BASH_SOURCE" "$@"
-fi
+	# allow the container to be started with `--user`
+	if [ "$user" = '0' ]; then
+		find "$PGDATA" \! -user postgres -exec chown postgres '{}' +
+		find /var/run/postgresql \! -user postgres -exec chown postgres '{}' +
+	fi
+}
 
-if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+# initialize empty PGDATA directory with new database via 'initdb'
+# arguments to `initdb` can be passed via POSTGRES_INITDB_ARGS or as arguments to this function
+# `initdb` automatically creates the "postgres", "template0", and "template1" dbnames
+# this is also where the database user is created, specified by `POSTGRES_USER` env
+docker_init_database_dir() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
 
-	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ ! -s "$PGDATA/PG_VERSION" ]; then
-		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
-		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
-		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
-			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
-			export NSS_WRAPPER_PASSWD="$(mktemp)"
-			export NSS_WRAPPER_GROUP="$(mktemp)"
-			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
-			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
-		fi
+	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
+	fi
 
-		file_env 'POSTGRES_USER' 'postgres'
-		file_env 'POSTGRES_PASSWORD'
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
 
-		file_env 'POSTGRES_INITDB_ARGS'
-		if [ "$POSTGRES_INITDB_WALDIR" ]; then
-			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --waldir $POSTGRES_INITDB_WALDIR"
-		fi
-		eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
 
-		# unset/cleanup "nss_wrapper" bits
-		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
-			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
-			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
-		fi
+# print large warning if POSTGRES_PASSWORD is empty
+docker_verify_minimum_env() {
+	# check password first so we can output the warning before postgres
+	# messes it up
+	if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
+		cat >&2 <<-'EOWARN'
 
-		# check password first so we can output the warning before postgres
-		# messes it up
-		if [ -n "$POSTGRES_PASSWORD" ]; then
-			authMethod=md5
+			WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
 
-			if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
-				cat >&2 <<-'EOWARN'
+			  This will not work if used via PGPASSWORD with "psql".
 
-					WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
+			  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
+			  https://github.com/docker-library/postgres/issues/507
 
-					  This will not work if used via PGPASSWORD with "psql".
+		EOWARN
+	fi
+	if [ -z "$POSTGRES_PASSWORD" ]; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+			****************************************************
+			WARNING: No password has been set for the database.
+			         This will allow anyone with access to the
+			         Postgres port to access your database. In
+			         Docker's default configuration, this is
+			         effectively any other container on the same
+			         system.
 
-					  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
-					  https://github.com/docker-library/postgres/issues/507
+			         Use "-e POSTGRES_PASSWORD=password" to set
+			         it in "docker run".
+			****************************************************
+		EOWARN
 
-				EOWARN
-			fi
-		else
-			# The - option suppresses leading tabs but *not* spaces. :)
-			cat >&2 <<-'EOWARN'
-				****************************************************
-				WARNING: No password has been set for the database.
-				         This will allow anyone with access to the
-				         Postgres port to access your database. In
-				         Docker's default configuration, this is
-				         effectively any other container on the same
-				         system.
+	fi
+}
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
-				****************************************************
-			EOWARN
+# usage: docker_process_init_files [file [file [...]]]
+#    ie: docker_process_init_files /always-initdb.d/*
+# process initializer files, based on file extensions and permissions
+docker_process_init_files() {
+	# psql here for backwards compatiblilty "${psql[@]}"
+	psql=( docker_process_sql )
 
-			authMethod=trust
-		fi
-
-		{
-			echo
-			echo "host all all all $authMethod"
-		} >> "$PGDATA/pg_hba.conf"
-
-		# internal start of server in order to allow set-up using psql-client
-		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
-
-		file_env 'POSTGRES_DB' "$POSTGRES_USER"
-
-		export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
-		psql=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
-
-		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			"${psql[@]}" --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
-				CREATE DATABASE :"db" ;
-			EOSQL
-			echo
-		fi
-		psql+=( --dbname "$POSTGRES_DB" )
-
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					echo "$0: running $f"
+					"$f"
+				else
+					echo "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
+			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*)        echo "$0: ignoring $f" ;;
+		esac
 		echo
-		for f in /docker-entrypoint-initdb.d/*; do
-			case "$f" in
-				*.sh)
-					# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
-					# https://github.com/docker-library/postgres/pull/452
-					if [ -x "$f" ]; then
-						echo "$0: running $f"
-						"$f"
-					else
-						echo "$0: sourcing $f"
-						. "$f"
-					fi
-					;;
-				*.sql)    echo "$0: running $f"; "${psql[@]}" -f "$f"; echo ;;
-				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${psql[@]}"; echo ;;
-				*)        echo "$0: ignoring $f" ;;
-			esac
-			echo
-		done
+	done
+}
 
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" -m fast -w stop
+# Execute sql script, passed via stdin (or -f flag of pqsl)
+# usage: docker_process_sql [psql-cli-args]
+#    ie: docker_process_sql --dbname=mydb <<<'INSERT ...'
+#    ie: docker_process_sql -f my-file.sql
+#    ie: docker_process_sql <my-file.sql
+docker_process_sql() {
+	local query_runner=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
+	if [ -n "$POSTGRES_DB" ]; then
+		query_runner+=( --dbname "$POSTGRES_DB" )
+	fi
 
-		unset PGPASSWORD
+	"${query_runner[@]}" "$@"
+}
 
-		echo
-		echo 'PostgreSQL init process complete; ready for start up.'
+# create initial database
+# uses environment variables for input: POSTGRES_DB
+docker_setup_db() {
+	if [ "$POSTGRES_DB" != 'postgres' ]; then
+		POSTGRES_DB= docker_process_sql --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
+			CREATE DATABASE :"db" ;
+		EOSQL
 		echo
 	fi
-fi
+}
 
-exec "$@"
+# Loads various settings that are used elsewhere in the script
+# This should be called before any other functions
+docker_setup_env() {
+	file_env 'POSTGRES_PASSWORD'
+
+	file_env 'POSTGRES_USER' 'postgres'
+	file_env 'POSTGRES_DB' "$POSTGRES_USER"
+	file_env 'POSTGRES_INITDB_ARGS'
+
+	declare -g DATABASE_ALREADY_EXISTS
+	# look specifically for PG_VERSION, as it is expected in the DB dir
+	if [ -s "$PGDATA/PG_VERSION" ]; then
+		DATABASE_ALREADY_EXISTS='true'
+	fi
+}
+
+# append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
+pg_setup_hba_conf() {
+	local authMethod
+	if [ "$POSTGRES_PASSWORD" ]; then
+		authMethod='md5'
+	else
+		authMethod='trust'
+	fi
+
+	{
+		echo
+		echo "host all all all $authMethod"
+	} >> "$PGDATA/pg_hba.conf"
+}
+
+# start socket-only postgresql server for setting up or running scripts
+# all arguments will be passed along as arguments to `postgres` (via pg_ctl)
+docker_temp_server_start() {
+	if [ "$1" = 'postgres' ]; then
+		shift
+	fi
+	# internal start of server in order to allow setup using psql client
+	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-w start
+}
+
+# stop postgresql server after done setting up user and running scripts
+docker_temp_server_stop() {
+	PGUSER="${PGUSER:-postgres}" \
+	pg_ctl -D "$PGDATA" -m fast -w stop
+}
+
+_main() {
+	# if first arg looks like a flag, assume we want to run postgres server
+	if [ "${1:0:1}" = '-' ]; then
+		set -- postgres "$@"
+	fi
+
+
+	if [ "$1" = 'postgres' ]; then
+		docker_setup_env
+		# setup data directories and permissions (when run as root)
+		docker_create_db_directories
+		if [ "$(id -u)" = '0' ]; then
+			# then restart script as postgres user
+			exec gosu postgres "$BASH_SOURCE" "$@"
+		fi
+
+		# only run initialization on an empty data directory
+		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+			docker_verify_minimum_env
+			docker_init_database_dir
+			pg_setup_hba_conf
+
+			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+			# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+			export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+			docker_temp_server_start "$@"
+
+			docker_setup_db
+			docker_process_init_files /docker-entrypoint-initdb.d/*
+
+			docker_temp_server_stop
+			unset PGPASSWORD
+
+			echo
+			echo 'PostgreSQL init process complete; ready for start up.'
+			echo
+		else
+			echo
+			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
+			echo
+		fi
+	fi
+
+	exec "$@"
+}
+
+if ! _is_sourced; then
+	_main "$@"
+fi

--- a/11/docker-entrypoint.sh
+++ b/11/docker-entrypoint.sh
@@ -34,7 +34,7 @@ _is_sourced() {
 
 # used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
 docker_create_db_directories() {
-	local user="$(id -u)"
+	local user; user="$(id -u)"
 
 	mkdir -p "$PGDATA"
 	chmod 700 "$PGDATA"
@@ -46,7 +46,9 @@ docker_create_db_directories() {
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
-		[ "$user" = '0' ] && find "$POSTGRES_INITDB_WALDIR" \! -user postgres - exec chown postgres '{}' +
+		if [ "$user" = '0' ]; then
+			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
+		fi
 		chmod 700 "$POSTGRES_INITDB_WALDIR"
 	fi
 
@@ -193,10 +195,8 @@ docker_setup_env() {
 
 # append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
 pg_setup_hba_conf() {
-	local authMethod
-	if [ "$POSTGRES_PASSWORD" ]; then
-		authMethod='md5'
-	else
+	local authMethod='md5'
+	if [ -z "$POSTGRES_PASSWORD" ]; then
 		authMethod='trust'
 	fi
 
@@ -231,7 +231,6 @@ _main() {
 	if [ "${1:0:1}" = '-' ]; then
 		set -- postgres "$@"
 	fi
-
 
 	if [ "$1" = 'postgres' ]; then
 		docker_setup_env

--- a/12/alpine/docker-entrypoint.sh
+++ b/12/alpine/docker-entrypoint.sh
@@ -24,153 +24,254 @@ file_env() {
 	unset "$fileVar"
 }
 
-if [ "${1:0:1}" = '-' ]; then
-	set -- postgres "$@"
-fi
+# check to see if this file is being run or sourced from another script
+_is_sourced() {
+	# https://unix.stackexchange.com/a/215279
+	[ "${#FUNCNAME[@]}" -ge 2 ] \
+		&& [ "${FUNCNAME[0]}" = '_is_sourced' ] \
+		&& [ "${FUNCNAME[1]}" = 'source' ]
+}
 
-# allow the container to be started with `--user`
-if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
+# used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
+docker_create_db_directories() {
+	local user="$(id -u)"
+
 	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
 
-	mkdir -p /var/run/postgresql
-	chown -R postgres /var/run/postgresql
-	chmod 775 /var/run/postgresql
+	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
+	mkdir -p /var/run/postgresql || :
+	chmod 775 /var/run/postgresql || :
 
-	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
+	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
-		chown -R postgres "$POSTGRES_INITDB_WALDIR"
+		[ "$user" = '0' ] && find "$POSTGRES_INITDB_WALDIR" \! -user postgres - exec chown postgres '{}' +
 		chmod 700 "$POSTGRES_INITDB_WALDIR"
 	fi
 
-	exec su-exec postgres "$BASH_SOURCE" "$@"
-fi
+	# allow the container to be started with `--user`
+	if [ "$user" = '0' ]; then
+		find "$PGDATA" \! -user postgres -exec chown postgres '{}' +
+		find /var/run/postgresql \! -user postgres -exec chown postgres '{}' +
+	fi
+}
 
-if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+# initialize empty PGDATA directory with new database via 'initdb'
+# arguments to `initdb` can be passed via POSTGRES_INITDB_ARGS or as arguments to this function
+# `initdb` automatically creates the "postgres", "template0", and "template1" dbnames
+# this is also where the database user is created, specified by `POSTGRES_USER` env
+docker_init_database_dir() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
 
-	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ ! -s "$PGDATA/PG_VERSION" ]; then
-		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
-		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
-		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
-			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
-			export NSS_WRAPPER_PASSWD="$(mktemp)"
-			export NSS_WRAPPER_GROUP="$(mktemp)"
-			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
-			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
-		fi
+	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
+	fi
 
-		file_env 'POSTGRES_USER' 'postgres'
-		file_env 'POSTGRES_PASSWORD'
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
 
-		file_env 'POSTGRES_INITDB_ARGS'
-		if [ "$POSTGRES_INITDB_WALDIR" ]; then
-			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --waldir $POSTGRES_INITDB_WALDIR"
-		fi
-		eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
 
-		# unset/cleanup "nss_wrapper" bits
-		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
-			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
-			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
-		fi
+# print large warning if POSTGRES_PASSWORD is empty
+docker_verify_minimum_env() {
+	# check password first so we can output the warning before postgres
+	# messes it up
+	if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
+		cat >&2 <<-'EOWARN'
 
-		# check password first so we can output the warning before postgres
-		# messes it up
-		if [ -n "$POSTGRES_PASSWORD" ]; then
-			authMethod=md5
+			WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
 
-			if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
-				cat >&2 <<-'EOWARN'
+			  This will not work if used via PGPASSWORD with "psql".
 
-					WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
+			  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
+			  https://github.com/docker-library/postgres/issues/507
 
-					  This will not work if used via PGPASSWORD with "psql".
+		EOWARN
+	fi
+	if [ -z "$POSTGRES_PASSWORD" ]; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+			****************************************************
+			WARNING: No password has been set for the database.
+			         This will allow anyone with access to the
+			         Postgres port to access your database. In
+			         Docker's default configuration, this is
+			         effectively any other container on the same
+			         system.
 
-					  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
-					  https://github.com/docker-library/postgres/issues/507
+			         Use "-e POSTGRES_PASSWORD=password" to set
+			         it in "docker run".
+			****************************************************
+		EOWARN
 
-				EOWARN
-			fi
-		else
-			# The - option suppresses leading tabs but *not* spaces. :)
-			cat >&2 <<-'EOWARN'
-				****************************************************
-				WARNING: No password has been set for the database.
-				         This will allow anyone with access to the
-				         Postgres port to access your database. In
-				         Docker's default configuration, this is
-				         effectively any other container on the same
-				         system.
+	fi
+}
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
-				****************************************************
-			EOWARN
+# usage: docker_process_init_files [file [file [...]]]
+#    ie: docker_process_init_files /always-initdb.d/*
+# process initializer files, based on file extensions and permissions
+docker_process_init_files() {
+	# psql here for backwards compatiblilty "${psql[@]}"
+	psql=( docker_process_sql )
 
-			authMethod=trust
-		fi
-
-		{
-			echo
-			echo "host all all all $authMethod"
-		} >> "$PGDATA/pg_hba.conf"
-
-		# internal start of server in order to allow set-up using psql-client
-		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
-
-		file_env 'POSTGRES_DB' "$POSTGRES_USER"
-
-		export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
-		psql=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
-
-		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			"${psql[@]}" --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
-				CREATE DATABASE :"db" ;
-			EOSQL
-			echo
-		fi
-		psql+=( --dbname "$POSTGRES_DB" )
-
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					echo "$0: running $f"
+					"$f"
+				else
+					echo "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
+			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*)        echo "$0: ignoring $f" ;;
+		esac
 		echo
-		for f in /docker-entrypoint-initdb.d/*; do
-			case "$f" in
-				*.sh)
-					# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
-					# https://github.com/docker-library/postgres/pull/452
-					if [ -x "$f" ]; then
-						echo "$0: running $f"
-						"$f"
-					else
-						echo "$0: sourcing $f"
-						. "$f"
-					fi
-					;;
-				*.sql)    echo "$0: running $f"; "${psql[@]}" -f "$f"; echo ;;
-				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${psql[@]}"; echo ;;
-				*)        echo "$0: ignoring $f" ;;
-			esac
-			echo
-		done
+	done
+}
 
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" -m fast -w stop
+# Execute sql script, passed via stdin (or -f flag of pqsl)
+# usage: docker_process_sql [psql-cli-args]
+#    ie: docker_process_sql --dbname=mydb <<<'INSERT ...'
+#    ie: docker_process_sql -f my-file.sql
+#    ie: docker_process_sql <my-file.sql
+docker_process_sql() {
+	local query_runner=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
+	if [ -n "$POSTGRES_DB" ]; then
+		query_runner+=( --dbname "$POSTGRES_DB" )
+	fi
 
-		unset PGPASSWORD
+	"${query_runner[@]}" "$@"
+}
 
-		echo
-		echo 'PostgreSQL init process complete; ready for start up.'
+# create initial database
+# uses environment variables for input: POSTGRES_DB
+docker_setup_db() {
+	if [ "$POSTGRES_DB" != 'postgres' ]; then
+		POSTGRES_DB= docker_process_sql --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
+			CREATE DATABASE :"db" ;
+		EOSQL
 		echo
 	fi
-fi
+}
 
-exec "$@"
+# Loads various settings that are used elsewhere in the script
+# This should be called before any other functions
+docker_setup_env() {
+	file_env 'POSTGRES_PASSWORD'
+
+	file_env 'POSTGRES_USER' 'postgres'
+	file_env 'POSTGRES_DB' "$POSTGRES_USER"
+	file_env 'POSTGRES_INITDB_ARGS'
+
+	declare -g DATABASE_ALREADY_EXISTS
+	# look specifically for PG_VERSION, as it is expected in the DB dir
+	if [ -s "$PGDATA/PG_VERSION" ]; then
+		DATABASE_ALREADY_EXISTS='true'
+	fi
+}
+
+# append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
+pg_setup_hba_conf() {
+	local authMethod
+	if [ "$POSTGRES_PASSWORD" ]; then
+		authMethod='md5'
+	else
+		authMethod='trust'
+	fi
+
+	{
+		echo
+		echo "host all all all $authMethod"
+	} >> "$PGDATA/pg_hba.conf"
+}
+
+# start socket-only postgresql server for setting up or running scripts
+# all arguments will be passed along as arguments to `postgres` (via pg_ctl)
+docker_temp_server_start() {
+	if [ "$1" = 'postgres' ]; then
+		shift
+	fi
+	# internal start of server in order to allow setup using psql client
+	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-w start
+}
+
+# stop postgresql server after done setting up user and running scripts
+docker_temp_server_stop() {
+	PGUSER="${PGUSER:-postgres}" \
+	pg_ctl -D "$PGDATA" -m fast -w stop
+}
+
+_main() {
+	# if first arg looks like a flag, assume we want to run postgres server
+	if [ "${1:0:1}" = '-' ]; then
+		set -- postgres "$@"
+	fi
+
+
+	if [ "$1" = 'postgres' ]; then
+		docker_setup_env
+		# setup data directories and permissions (when run as root)
+		docker_create_db_directories
+		if [ "$(id -u)" = '0' ]; then
+			# then restart script as postgres user
+			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		# only run initialization on an empty data directory
+		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+			docker_verify_minimum_env
+			docker_init_database_dir
+			pg_setup_hba_conf
+
+			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+			# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+			export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+			docker_temp_server_start "$@"
+
+			docker_setup_db
+			docker_process_init_files /docker-entrypoint-initdb.d/*
+
+			docker_temp_server_stop
+			unset PGPASSWORD
+
+			echo
+			echo 'PostgreSQL init process complete; ready for start up.'
+			echo
+		else
+			echo
+			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
+			echo
+		fi
+	fi
+
+	exec "$@"
+}
+
+if ! _is_sourced; then
+	_main "$@"
+fi

--- a/12/alpine/docker-entrypoint.sh
+++ b/12/alpine/docker-entrypoint.sh
@@ -34,7 +34,7 @@ _is_sourced() {
 
 # used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
 docker_create_db_directories() {
-	local user="$(id -u)"
+	local user; user="$(id -u)"
 
 	mkdir -p "$PGDATA"
 	chmod 700 "$PGDATA"
@@ -46,7 +46,9 @@ docker_create_db_directories() {
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
-		[ "$user" = '0' ] && find "$POSTGRES_INITDB_WALDIR" \! -user postgres - exec chown postgres '{}' +
+		if [ "$user" = '0' ]; then
+			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
+		fi
 		chmod 700 "$POSTGRES_INITDB_WALDIR"
 	fi
 
@@ -193,10 +195,8 @@ docker_setup_env() {
 
 # append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
 pg_setup_hba_conf() {
-	local authMethod
-	if [ "$POSTGRES_PASSWORD" ]; then
-		authMethod='md5'
-	else
+	local authMethod='md5'
+	if [ -z "$POSTGRES_PASSWORD" ]; then
 		authMethod='trust'
 	fi
 
@@ -231,7 +231,6 @@ _main() {
 	if [ "${1:0:1}" = '-' ]; then
 		set -- postgres "$@"
 	fi
-
 
 	if [ "$1" = 'postgres' ]; then
 		docker_setup_env

--- a/12/docker-entrypoint.sh
+++ b/12/docker-entrypoint.sh
@@ -24,153 +24,254 @@ file_env() {
 	unset "$fileVar"
 }
 
-if [ "${1:0:1}" = '-' ]; then
-	set -- postgres "$@"
-fi
+# check to see if this file is being run or sourced from another script
+_is_sourced() {
+	# https://unix.stackexchange.com/a/215279
+	[ "${#FUNCNAME[@]}" -ge 2 ] \
+		&& [ "${FUNCNAME[0]}" = '_is_sourced' ] \
+		&& [ "${FUNCNAME[1]}" = 'source' ]
+}
 
-# allow the container to be started with `--user`
-if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
+# used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
+docker_create_db_directories() {
+	local user="$(id -u)"
+
 	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
 
-	mkdir -p /var/run/postgresql
-	chown -R postgres /var/run/postgresql
-	chmod 775 /var/run/postgresql
+	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
+	mkdir -p /var/run/postgresql || :
+	chmod 775 /var/run/postgresql || :
 
-	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
+	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
-		chown -R postgres "$POSTGRES_INITDB_WALDIR"
+		[ "$user" = '0' ] && find "$POSTGRES_INITDB_WALDIR" \! -user postgres - exec chown postgres '{}' +
 		chmod 700 "$POSTGRES_INITDB_WALDIR"
 	fi
 
-	exec gosu postgres "$BASH_SOURCE" "$@"
-fi
+	# allow the container to be started with `--user`
+	if [ "$user" = '0' ]; then
+		find "$PGDATA" \! -user postgres -exec chown postgres '{}' +
+		find /var/run/postgresql \! -user postgres -exec chown postgres '{}' +
+	fi
+}
 
-if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+# initialize empty PGDATA directory with new database via 'initdb'
+# arguments to `initdb` can be passed via POSTGRES_INITDB_ARGS or as arguments to this function
+# `initdb` automatically creates the "postgres", "template0", and "template1" dbnames
+# this is also where the database user is created, specified by `POSTGRES_USER` env
+docker_init_database_dir() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
 
-	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ ! -s "$PGDATA/PG_VERSION" ]; then
-		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
-		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
-		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
-			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
-			export NSS_WRAPPER_PASSWD="$(mktemp)"
-			export NSS_WRAPPER_GROUP="$(mktemp)"
-			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
-			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
-		fi
+	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
+	fi
 
-		file_env 'POSTGRES_USER' 'postgres'
-		file_env 'POSTGRES_PASSWORD'
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
 
-		file_env 'POSTGRES_INITDB_ARGS'
-		if [ "$POSTGRES_INITDB_WALDIR" ]; then
-			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --waldir $POSTGRES_INITDB_WALDIR"
-		fi
-		eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
 
-		# unset/cleanup "nss_wrapper" bits
-		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
-			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
-			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
-		fi
+# print large warning if POSTGRES_PASSWORD is empty
+docker_verify_minimum_env() {
+	# check password first so we can output the warning before postgres
+	# messes it up
+	if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
+		cat >&2 <<-'EOWARN'
 
-		# check password first so we can output the warning before postgres
-		# messes it up
-		if [ -n "$POSTGRES_PASSWORD" ]; then
-			authMethod=md5
+			WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
 
-			if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
-				cat >&2 <<-'EOWARN'
+			  This will not work if used via PGPASSWORD with "psql".
 
-					WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
+			  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
+			  https://github.com/docker-library/postgres/issues/507
 
-					  This will not work if used via PGPASSWORD with "psql".
+		EOWARN
+	fi
+	if [ -z "$POSTGRES_PASSWORD" ]; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+			****************************************************
+			WARNING: No password has been set for the database.
+			         This will allow anyone with access to the
+			         Postgres port to access your database. In
+			         Docker's default configuration, this is
+			         effectively any other container on the same
+			         system.
 
-					  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
-					  https://github.com/docker-library/postgres/issues/507
+			         Use "-e POSTGRES_PASSWORD=password" to set
+			         it in "docker run".
+			****************************************************
+		EOWARN
 
-				EOWARN
-			fi
-		else
-			# The - option suppresses leading tabs but *not* spaces. :)
-			cat >&2 <<-'EOWARN'
-				****************************************************
-				WARNING: No password has been set for the database.
-				         This will allow anyone with access to the
-				         Postgres port to access your database. In
-				         Docker's default configuration, this is
-				         effectively any other container on the same
-				         system.
+	fi
+}
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
-				****************************************************
-			EOWARN
+# usage: docker_process_init_files [file [file [...]]]
+#    ie: docker_process_init_files /always-initdb.d/*
+# process initializer files, based on file extensions and permissions
+docker_process_init_files() {
+	# psql here for backwards compatiblilty "${psql[@]}"
+	psql=( docker_process_sql )
 
-			authMethod=trust
-		fi
-
-		{
-			echo
-			echo "host all all all $authMethod"
-		} >> "$PGDATA/pg_hba.conf"
-
-		# internal start of server in order to allow set-up using psql-client
-		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
-
-		file_env 'POSTGRES_DB' "$POSTGRES_USER"
-
-		export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
-		psql=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
-
-		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			"${psql[@]}" --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
-				CREATE DATABASE :"db" ;
-			EOSQL
-			echo
-		fi
-		psql+=( --dbname "$POSTGRES_DB" )
-
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					echo "$0: running $f"
+					"$f"
+				else
+					echo "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
+			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*)        echo "$0: ignoring $f" ;;
+		esac
 		echo
-		for f in /docker-entrypoint-initdb.d/*; do
-			case "$f" in
-				*.sh)
-					# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
-					# https://github.com/docker-library/postgres/pull/452
-					if [ -x "$f" ]; then
-						echo "$0: running $f"
-						"$f"
-					else
-						echo "$0: sourcing $f"
-						. "$f"
-					fi
-					;;
-				*.sql)    echo "$0: running $f"; "${psql[@]}" -f "$f"; echo ;;
-				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${psql[@]}"; echo ;;
-				*)        echo "$0: ignoring $f" ;;
-			esac
-			echo
-		done
+	done
+}
 
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" -m fast -w stop
+# Execute sql script, passed via stdin (or -f flag of pqsl)
+# usage: docker_process_sql [psql-cli-args]
+#    ie: docker_process_sql --dbname=mydb <<<'INSERT ...'
+#    ie: docker_process_sql -f my-file.sql
+#    ie: docker_process_sql <my-file.sql
+docker_process_sql() {
+	local query_runner=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
+	if [ -n "$POSTGRES_DB" ]; then
+		query_runner+=( --dbname "$POSTGRES_DB" )
+	fi
 
-		unset PGPASSWORD
+	"${query_runner[@]}" "$@"
+}
 
-		echo
-		echo 'PostgreSQL init process complete; ready for start up.'
+# create initial database
+# uses environment variables for input: POSTGRES_DB
+docker_setup_db() {
+	if [ "$POSTGRES_DB" != 'postgres' ]; then
+		POSTGRES_DB= docker_process_sql --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
+			CREATE DATABASE :"db" ;
+		EOSQL
 		echo
 	fi
-fi
+}
 
-exec "$@"
+# Loads various settings that are used elsewhere in the script
+# This should be called before any other functions
+docker_setup_env() {
+	file_env 'POSTGRES_PASSWORD'
+
+	file_env 'POSTGRES_USER' 'postgres'
+	file_env 'POSTGRES_DB' "$POSTGRES_USER"
+	file_env 'POSTGRES_INITDB_ARGS'
+
+	declare -g DATABASE_ALREADY_EXISTS
+	# look specifically for PG_VERSION, as it is expected in the DB dir
+	if [ -s "$PGDATA/PG_VERSION" ]; then
+		DATABASE_ALREADY_EXISTS='true'
+	fi
+}
+
+# append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
+pg_setup_hba_conf() {
+	local authMethod
+	if [ "$POSTGRES_PASSWORD" ]; then
+		authMethod='md5'
+	else
+		authMethod='trust'
+	fi
+
+	{
+		echo
+		echo "host all all all $authMethod"
+	} >> "$PGDATA/pg_hba.conf"
+}
+
+# start socket-only postgresql server for setting up or running scripts
+# all arguments will be passed along as arguments to `postgres` (via pg_ctl)
+docker_temp_server_start() {
+	if [ "$1" = 'postgres' ]; then
+		shift
+	fi
+	# internal start of server in order to allow setup using psql client
+	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-w start
+}
+
+# stop postgresql server after done setting up user and running scripts
+docker_temp_server_stop() {
+	PGUSER="${PGUSER:-postgres}" \
+	pg_ctl -D "$PGDATA" -m fast -w stop
+}
+
+_main() {
+	# if first arg looks like a flag, assume we want to run postgres server
+	if [ "${1:0:1}" = '-' ]; then
+		set -- postgres "$@"
+	fi
+
+
+	if [ "$1" = 'postgres' ]; then
+		docker_setup_env
+		# setup data directories and permissions (when run as root)
+		docker_create_db_directories
+		if [ "$(id -u)" = '0' ]; then
+			# then restart script as postgres user
+			exec gosu postgres "$BASH_SOURCE" "$@"
+		fi
+
+		# only run initialization on an empty data directory
+		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+			docker_verify_minimum_env
+			docker_init_database_dir
+			pg_setup_hba_conf
+
+			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+			# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+			export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+			docker_temp_server_start "$@"
+
+			docker_setup_db
+			docker_process_init_files /docker-entrypoint-initdb.d/*
+
+			docker_temp_server_stop
+			unset PGPASSWORD
+
+			echo
+			echo 'PostgreSQL init process complete; ready for start up.'
+			echo
+		else
+			echo
+			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
+			echo
+		fi
+	fi
+
+	exec "$@"
+}
+
+if ! _is_sourced; then
+	_main "$@"
+fi

--- a/12/docker-entrypoint.sh
+++ b/12/docker-entrypoint.sh
@@ -34,7 +34,7 @@ _is_sourced() {
 
 # used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
 docker_create_db_directories() {
-	local user="$(id -u)"
+	local user; user="$(id -u)"
 
 	mkdir -p "$PGDATA"
 	chmod 700 "$PGDATA"
@@ -46,7 +46,9 @@ docker_create_db_directories() {
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
-		[ "$user" = '0' ] && find "$POSTGRES_INITDB_WALDIR" \! -user postgres - exec chown postgres '{}' +
+		if [ "$user" = '0' ]; then
+			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
+		fi
 		chmod 700 "$POSTGRES_INITDB_WALDIR"
 	fi
 
@@ -193,10 +195,8 @@ docker_setup_env() {
 
 # append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
 pg_setup_hba_conf() {
-	local authMethod
-	if [ "$POSTGRES_PASSWORD" ]; then
-		authMethod='md5'
-	else
+	local authMethod='md5'
+	if [ -z "$POSTGRES_PASSWORD" ]; then
 		authMethod='trust'
 	fi
 
@@ -231,7 +231,6 @@ _main() {
 	if [ "${1:0:1}" = '-' ]; then
 		set -- postgres "$@"
 	fi
-
 
 	if [ "$1" = 'postgres' ]; then
 		docker_setup_env

--- a/9.4/alpine/docker-entrypoint.sh
+++ b/9.4/alpine/docker-entrypoint.sh
@@ -24,153 +24,254 @@ file_env() {
 	unset "$fileVar"
 }
 
-if [ "${1:0:1}" = '-' ]; then
-	set -- postgres "$@"
-fi
+# check to see if this file is being run or sourced from another script
+_is_sourced() {
+	# https://unix.stackexchange.com/a/215279
+	[ "${#FUNCNAME[@]}" -ge 2 ] \
+		&& [ "${FUNCNAME[0]}" = '_is_sourced' ] \
+		&& [ "${FUNCNAME[1]}" = 'source' ]
+}
 
-# allow the container to be started with `--user`
-if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
+# used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
+docker_create_db_directories() {
+	local user="$(id -u)"
+
 	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
 
-	mkdir -p /var/run/postgresql
-	chown -R postgres /var/run/postgresql
-	chmod 775 /var/run/postgresql
+	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
+	mkdir -p /var/run/postgresql || :
+	chmod 775 /var/run/postgresql || :
 
-	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
+	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_XLOGDIR"
-		chown -R postgres "$POSTGRES_INITDB_XLOGDIR"
+		[ "$user" = '0' ] && find "$POSTGRES_INITDB_XLOGDIR" \! -user postgres - exec chown postgres '{}' +
 		chmod 700 "$POSTGRES_INITDB_XLOGDIR"
 	fi
 
-	exec su-exec postgres "$BASH_SOURCE" "$@"
-fi
+	# allow the container to be started with `--user`
+	if [ "$user" = '0' ]; then
+		find "$PGDATA" \! -user postgres -exec chown postgres '{}' +
+		find /var/run/postgresql \! -user postgres -exec chown postgres '{}' +
+	fi
+}
 
-if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+# initialize empty PGDATA directory with new database via 'initdb'
+# arguments to `initdb` can be passed via POSTGRES_INITDB_ARGS or as arguments to this function
+# `initdb` automatically creates the "postgres", "template0", and "template1" dbnames
+# this is also where the database user is created, specified by `POSTGRES_USER` env
+docker_init_database_dir() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
 
-	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ ! -s "$PGDATA/PG_VERSION" ]; then
-		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
-		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
-		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
-			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
-			export NSS_WRAPPER_PASSWD="$(mktemp)"
-			export NSS_WRAPPER_GROUP="$(mktemp)"
-			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
-			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
-		fi
+	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+		set -- --xlogdir "$POSTGRES_INITDB_XLOGDIR" "$@"
+	fi
 
-		file_env 'POSTGRES_USER' 'postgres'
-		file_env 'POSTGRES_PASSWORD'
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
 
-		file_env 'POSTGRES_INITDB_ARGS'
-		if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
-			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --xlogdir $POSTGRES_INITDB_XLOGDIR"
-		fi
-		eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
 
-		# unset/cleanup "nss_wrapper" bits
-		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
-			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
-			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
-		fi
+# print large warning if POSTGRES_PASSWORD is empty
+docker_verify_minimum_env() {
+	# check password first so we can output the warning before postgres
+	# messes it up
+	if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
+		cat >&2 <<-'EOWARN'
 
-		# check password first so we can output the warning before postgres
-		# messes it up
-		if [ -n "$POSTGRES_PASSWORD" ]; then
-			authMethod=md5
+			WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
 
-			if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
-				cat >&2 <<-'EOWARN'
+			  This will not work if used via PGPASSWORD with "psql".
 
-					WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
+			  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
+			  https://github.com/docker-library/postgres/issues/507
 
-					  This will not work if used via PGPASSWORD with "psql".
+		EOWARN
+	fi
+	if [ -z "$POSTGRES_PASSWORD" ]; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+			****************************************************
+			WARNING: No password has been set for the database.
+			         This will allow anyone with access to the
+			         Postgres port to access your database. In
+			         Docker's default configuration, this is
+			         effectively any other container on the same
+			         system.
 
-					  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
-					  https://github.com/docker-library/postgres/issues/507
+			         Use "-e POSTGRES_PASSWORD=password" to set
+			         it in "docker run".
+			****************************************************
+		EOWARN
 
-				EOWARN
-			fi
-		else
-			# The - option suppresses leading tabs but *not* spaces. :)
-			cat >&2 <<-'EOWARN'
-				****************************************************
-				WARNING: No password has been set for the database.
-				         This will allow anyone with access to the
-				         Postgres port to access your database. In
-				         Docker's default configuration, this is
-				         effectively any other container on the same
-				         system.
+	fi
+}
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
-				****************************************************
-			EOWARN
+# usage: docker_process_init_files [file [file [...]]]
+#    ie: docker_process_init_files /always-initdb.d/*
+# process initializer files, based on file extensions and permissions
+docker_process_init_files() {
+	# psql here for backwards compatiblilty "${psql[@]}"
+	psql=( docker_process_sql )
 
-			authMethod=trust
-		fi
-
-		{
-			echo
-			echo "host all all all $authMethod"
-		} >> "$PGDATA/pg_hba.conf"
-
-		# internal start of server in order to allow set-up using psql-client
-		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
-
-		file_env 'POSTGRES_DB' "$POSTGRES_USER"
-
-		export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
-		psql=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
-
-		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			"${psql[@]}" --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
-				CREATE DATABASE :"db" ;
-			EOSQL
-			echo
-		fi
-		psql+=( --dbname "$POSTGRES_DB" )
-
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					echo "$0: running $f"
+					"$f"
+				else
+					echo "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
+			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*)        echo "$0: ignoring $f" ;;
+		esac
 		echo
-		for f in /docker-entrypoint-initdb.d/*; do
-			case "$f" in
-				*.sh)
-					# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
-					# https://github.com/docker-library/postgres/pull/452
-					if [ -x "$f" ]; then
-						echo "$0: running $f"
-						"$f"
-					else
-						echo "$0: sourcing $f"
-						. "$f"
-					fi
-					;;
-				*.sql)    echo "$0: running $f"; "${psql[@]}" -f "$f"; echo ;;
-				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${psql[@]}"; echo ;;
-				*)        echo "$0: ignoring $f" ;;
-			esac
-			echo
-		done
+	done
+}
 
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" -m fast -w stop
+# Execute sql script, passed via stdin (or -f flag of pqsl)
+# usage: docker_process_sql [psql-cli-args]
+#    ie: docker_process_sql --dbname=mydb <<<'INSERT ...'
+#    ie: docker_process_sql -f my-file.sql
+#    ie: docker_process_sql <my-file.sql
+docker_process_sql() {
+	local query_runner=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
+	if [ -n "$POSTGRES_DB" ]; then
+		query_runner+=( --dbname "$POSTGRES_DB" )
+	fi
 
-		unset PGPASSWORD
+	"${query_runner[@]}" "$@"
+}
 
-		echo
-		echo 'PostgreSQL init process complete; ready for start up.'
+# create initial database
+# uses environment variables for input: POSTGRES_DB
+docker_setup_db() {
+	if [ "$POSTGRES_DB" != 'postgres' ]; then
+		POSTGRES_DB= docker_process_sql --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
+			CREATE DATABASE :"db" ;
+		EOSQL
 		echo
 	fi
-fi
+}
 
-exec "$@"
+# Loads various settings that are used elsewhere in the script
+# This should be called before any other functions
+docker_setup_env() {
+	file_env 'POSTGRES_PASSWORD'
+
+	file_env 'POSTGRES_USER' 'postgres'
+	file_env 'POSTGRES_DB' "$POSTGRES_USER"
+	file_env 'POSTGRES_INITDB_ARGS'
+
+	declare -g DATABASE_ALREADY_EXISTS
+	# look specifically for PG_VERSION, as it is expected in the DB dir
+	if [ -s "$PGDATA/PG_VERSION" ]; then
+		DATABASE_ALREADY_EXISTS='true'
+	fi
+}
+
+# append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
+pg_setup_hba_conf() {
+	local authMethod
+	if [ "$POSTGRES_PASSWORD" ]; then
+		authMethod='md5'
+	else
+		authMethod='trust'
+	fi
+
+	{
+		echo
+		echo "host all all all $authMethod"
+	} >> "$PGDATA/pg_hba.conf"
+}
+
+# start socket-only postgresql server for setting up or running scripts
+# all arguments will be passed along as arguments to `postgres` (via pg_ctl)
+docker_temp_server_start() {
+	if [ "$1" = 'postgres' ]; then
+		shift
+	fi
+	# internal start of server in order to allow setup using psql client
+	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-w start
+}
+
+# stop postgresql server after done setting up user and running scripts
+docker_temp_server_stop() {
+	PGUSER="${PGUSER:-postgres}" \
+	pg_ctl -D "$PGDATA" -m fast -w stop
+}
+
+_main() {
+	# if first arg looks like a flag, assume we want to run postgres server
+	if [ "${1:0:1}" = '-' ]; then
+		set -- postgres "$@"
+	fi
+
+
+	if [ "$1" = 'postgres' ]; then
+		docker_setup_env
+		# setup data directories and permissions (when run as root)
+		docker_create_db_directories
+		if [ "$(id -u)" = '0' ]; then
+			# then restart script as postgres user
+			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		# only run initialization on an empty data directory
+		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+			docker_verify_minimum_env
+			docker_init_database_dir
+			pg_setup_hba_conf
+
+			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+			# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+			export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+			docker_temp_server_start "$@"
+
+			docker_setup_db
+			docker_process_init_files /docker-entrypoint-initdb.d/*
+
+			docker_temp_server_stop
+			unset PGPASSWORD
+
+			echo
+			echo 'PostgreSQL init process complete; ready for start up.'
+			echo
+		else
+			echo
+			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
+			echo
+		fi
+	fi
+
+	exec "$@"
+}
+
+if ! _is_sourced; then
+	_main "$@"
+fi

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -24,153 +24,254 @@ file_env() {
 	unset "$fileVar"
 }
 
-if [ "${1:0:1}" = '-' ]; then
-	set -- postgres "$@"
-fi
+# check to see if this file is being run or sourced from another script
+_is_sourced() {
+	# https://unix.stackexchange.com/a/215279
+	[ "${#FUNCNAME[@]}" -ge 2 ] \
+		&& [ "${FUNCNAME[0]}" = '_is_sourced' ] \
+		&& [ "${FUNCNAME[1]}" = 'source' ]
+}
 
-# allow the container to be started with `--user`
-if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
+# used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
+docker_create_db_directories() {
+	local user="$(id -u)"
+
 	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
 
-	mkdir -p /var/run/postgresql
-	chown -R postgres /var/run/postgresql
-	chmod 775 /var/run/postgresql
+	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
+	mkdir -p /var/run/postgresql || :
+	chmod 775 /var/run/postgresql || :
 
-	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
+	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_XLOGDIR"
-		chown -R postgres "$POSTGRES_INITDB_XLOGDIR"
+		[ "$user" = '0' ] && find "$POSTGRES_INITDB_XLOGDIR" \! -user postgres - exec chown postgres '{}' +
 		chmod 700 "$POSTGRES_INITDB_XLOGDIR"
 	fi
 
-	exec gosu postgres "$BASH_SOURCE" "$@"
-fi
+	# allow the container to be started with `--user`
+	if [ "$user" = '0' ]; then
+		find "$PGDATA" \! -user postgres -exec chown postgres '{}' +
+		find /var/run/postgresql \! -user postgres -exec chown postgres '{}' +
+	fi
+}
 
-if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+# initialize empty PGDATA directory with new database via 'initdb'
+# arguments to `initdb` can be passed via POSTGRES_INITDB_ARGS or as arguments to this function
+# `initdb` automatically creates the "postgres", "template0", and "template1" dbnames
+# this is also where the database user is created, specified by `POSTGRES_USER` env
+docker_init_database_dir() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
 
-	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ ! -s "$PGDATA/PG_VERSION" ]; then
-		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
-		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
-		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
-			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
-			export NSS_WRAPPER_PASSWD="$(mktemp)"
-			export NSS_WRAPPER_GROUP="$(mktemp)"
-			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
-			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
-		fi
+	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+		set -- --xlogdir "$POSTGRES_INITDB_XLOGDIR" "$@"
+	fi
 
-		file_env 'POSTGRES_USER' 'postgres'
-		file_env 'POSTGRES_PASSWORD'
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
 
-		file_env 'POSTGRES_INITDB_ARGS'
-		if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
-			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --xlogdir $POSTGRES_INITDB_XLOGDIR"
-		fi
-		eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
 
-		# unset/cleanup "nss_wrapper" bits
-		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
-			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
-			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
-		fi
+# print large warning if POSTGRES_PASSWORD is empty
+docker_verify_minimum_env() {
+	# check password first so we can output the warning before postgres
+	# messes it up
+	if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
+		cat >&2 <<-'EOWARN'
 
-		# check password first so we can output the warning before postgres
-		# messes it up
-		if [ -n "$POSTGRES_PASSWORD" ]; then
-			authMethod=md5
+			WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
 
-			if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
-				cat >&2 <<-'EOWARN'
+			  This will not work if used via PGPASSWORD with "psql".
 
-					WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
+			  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
+			  https://github.com/docker-library/postgres/issues/507
 
-					  This will not work if used via PGPASSWORD with "psql".
+		EOWARN
+	fi
+	if [ -z "$POSTGRES_PASSWORD" ]; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+			****************************************************
+			WARNING: No password has been set for the database.
+			         This will allow anyone with access to the
+			         Postgres port to access your database. In
+			         Docker's default configuration, this is
+			         effectively any other container on the same
+			         system.
 
-					  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
-					  https://github.com/docker-library/postgres/issues/507
+			         Use "-e POSTGRES_PASSWORD=password" to set
+			         it in "docker run".
+			****************************************************
+		EOWARN
 
-				EOWARN
-			fi
-		else
-			# The - option suppresses leading tabs but *not* spaces. :)
-			cat >&2 <<-'EOWARN'
-				****************************************************
-				WARNING: No password has been set for the database.
-				         This will allow anyone with access to the
-				         Postgres port to access your database. In
-				         Docker's default configuration, this is
-				         effectively any other container on the same
-				         system.
+	fi
+}
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
-				****************************************************
-			EOWARN
+# usage: docker_process_init_files [file [file [...]]]
+#    ie: docker_process_init_files /always-initdb.d/*
+# process initializer files, based on file extensions and permissions
+docker_process_init_files() {
+	# psql here for backwards compatiblilty "${psql[@]}"
+	psql=( docker_process_sql )
 
-			authMethod=trust
-		fi
-
-		{
-			echo
-			echo "host all all all $authMethod"
-		} >> "$PGDATA/pg_hba.conf"
-
-		# internal start of server in order to allow set-up using psql-client
-		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
-
-		file_env 'POSTGRES_DB' "$POSTGRES_USER"
-
-		export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
-		psql=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
-
-		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			"${psql[@]}" --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
-				CREATE DATABASE :"db" ;
-			EOSQL
-			echo
-		fi
-		psql+=( --dbname "$POSTGRES_DB" )
-
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					echo "$0: running $f"
+					"$f"
+				else
+					echo "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
+			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*)        echo "$0: ignoring $f" ;;
+		esac
 		echo
-		for f in /docker-entrypoint-initdb.d/*; do
-			case "$f" in
-				*.sh)
-					# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
-					# https://github.com/docker-library/postgres/pull/452
-					if [ -x "$f" ]; then
-						echo "$0: running $f"
-						"$f"
-					else
-						echo "$0: sourcing $f"
-						. "$f"
-					fi
-					;;
-				*.sql)    echo "$0: running $f"; "${psql[@]}" -f "$f"; echo ;;
-				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${psql[@]}"; echo ;;
-				*)        echo "$0: ignoring $f" ;;
-			esac
-			echo
-		done
+	done
+}
 
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" -m fast -w stop
+# Execute sql script, passed via stdin (or -f flag of pqsl)
+# usage: docker_process_sql [psql-cli-args]
+#    ie: docker_process_sql --dbname=mydb <<<'INSERT ...'
+#    ie: docker_process_sql -f my-file.sql
+#    ie: docker_process_sql <my-file.sql
+docker_process_sql() {
+	local query_runner=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
+	if [ -n "$POSTGRES_DB" ]; then
+		query_runner+=( --dbname "$POSTGRES_DB" )
+	fi
 
-		unset PGPASSWORD
+	"${query_runner[@]}" "$@"
+}
 
-		echo
-		echo 'PostgreSQL init process complete; ready for start up.'
+# create initial database
+# uses environment variables for input: POSTGRES_DB
+docker_setup_db() {
+	if [ "$POSTGRES_DB" != 'postgres' ]; then
+		POSTGRES_DB= docker_process_sql --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
+			CREATE DATABASE :"db" ;
+		EOSQL
 		echo
 	fi
-fi
+}
 
-exec "$@"
+# Loads various settings that are used elsewhere in the script
+# This should be called before any other functions
+docker_setup_env() {
+	file_env 'POSTGRES_PASSWORD'
+
+	file_env 'POSTGRES_USER' 'postgres'
+	file_env 'POSTGRES_DB' "$POSTGRES_USER"
+	file_env 'POSTGRES_INITDB_ARGS'
+
+	declare -g DATABASE_ALREADY_EXISTS
+	# look specifically for PG_VERSION, as it is expected in the DB dir
+	if [ -s "$PGDATA/PG_VERSION" ]; then
+		DATABASE_ALREADY_EXISTS='true'
+	fi
+}
+
+# append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
+pg_setup_hba_conf() {
+	local authMethod
+	if [ "$POSTGRES_PASSWORD" ]; then
+		authMethod='md5'
+	else
+		authMethod='trust'
+	fi
+
+	{
+		echo
+		echo "host all all all $authMethod"
+	} >> "$PGDATA/pg_hba.conf"
+}
+
+# start socket-only postgresql server for setting up or running scripts
+# all arguments will be passed along as arguments to `postgres` (via pg_ctl)
+docker_temp_server_start() {
+	if [ "$1" = 'postgres' ]; then
+		shift
+	fi
+	# internal start of server in order to allow setup using psql client
+	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-w start
+}
+
+# stop postgresql server after done setting up user and running scripts
+docker_temp_server_stop() {
+	PGUSER="${PGUSER:-postgres}" \
+	pg_ctl -D "$PGDATA" -m fast -w stop
+}
+
+_main() {
+	# if first arg looks like a flag, assume we want to run postgres server
+	if [ "${1:0:1}" = '-' ]; then
+		set -- postgres "$@"
+	fi
+
+
+	if [ "$1" = 'postgres' ]; then
+		docker_setup_env
+		# setup data directories and permissions (when run as root)
+		docker_create_db_directories
+		if [ "$(id -u)" = '0' ]; then
+			# then restart script as postgres user
+			exec gosu postgres "$BASH_SOURCE" "$@"
+		fi
+
+		# only run initialization on an empty data directory
+		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+			docker_verify_minimum_env
+			docker_init_database_dir
+			pg_setup_hba_conf
+
+			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+			# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+			export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+			docker_temp_server_start "$@"
+
+			docker_setup_db
+			docker_process_init_files /docker-entrypoint-initdb.d/*
+
+			docker_temp_server_stop
+			unset PGPASSWORD
+
+			echo
+			echo 'PostgreSQL init process complete; ready for start up.'
+			echo
+		else
+			echo
+			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
+			echo
+		fi
+	fi
+
+	exec "$@"
+}
+
+if ! _is_sourced; then
+	_main "$@"
+fi

--- a/9.5/alpine/docker-entrypoint.sh
+++ b/9.5/alpine/docker-entrypoint.sh
@@ -24,153 +24,254 @@ file_env() {
 	unset "$fileVar"
 }
 
-if [ "${1:0:1}" = '-' ]; then
-	set -- postgres "$@"
-fi
+# check to see if this file is being run or sourced from another script
+_is_sourced() {
+	# https://unix.stackexchange.com/a/215279
+	[ "${#FUNCNAME[@]}" -ge 2 ] \
+		&& [ "${FUNCNAME[0]}" = '_is_sourced' ] \
+		&& [ "${FUNCNAME[1]}" = 'source' ]
+}
 
-# allow the container to be started with `--user`
-if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
+# used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
+docker_create_db_directories() {
+	local user="$(id -u)"
+
 	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
 
-	mkdir -p /var/run/postgresql
-	chown -R postgres /var/run/postgresql
-	chmod 775 /var/run/postgresql
+	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
+	mkdir -p /var/run/postgresql || :
+	chmod 775 /var/run/postgresql || :
 
-	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
+	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_XLOGDIR"
-		chown -R postgres "$POSTGRES_INITDB_XLOGDIR"
+		[ "$user" = '0' ] && find "$POSTGRES_INITDB_XLOGDIR" \! -user postgres - exec chown postgres '{}' +
 		chmod 700 "$POSTGRES_INITDB_XLOGDIR"
 	fi
 
-	exec su-exec postgres "$BASH_SOURCE" "$@"
-fi
+	# allow the container to be started with `--user`
+	if [ "$user" = '0' ]; then
+		find "$PGDATA" \! -user postgres -exec chown postgres '{}' +
+		find /var/run/postgresql \! -user postgres -exec chown postgres '{}' +
+	fi
+}
 
-if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+# initialize empty PGDATA directory with new database via 'initdb'
+# arguments to `initdb` can be passed via POSTGRES_INITDB_ARGS or as arguments to this function
+# `initdb` automatically creates the "postgres", "template0", and "template1" dbnames
+# this is also where the database user is created, specified by `POSTGRES_USER` env
+docker_init_database_dir() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
 
-	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ ! -s "$PGDATA/PG_VERSION" ]; then
-		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
-		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
-		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
-			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
-			export NSS_WRAPPER_PASSWD="$(mktemp)"
-			export NSS_WRAPPER_GROUP="$(mktemp)"
-			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
-			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
-		fi
+	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+		set -- --xlogdir "$POSTGRES_INITDB_XLOGDIR" "$@"
+	fi
 
-		file_env 'POSTGRES_USER' 'postgres'
-		file_env 'POSTGRES_PASSWORD'
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
 
-		file_env 'POSTGRES_INITDB_ARGS'
-		if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
-			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --xlogdir $POSTGRES_INITDB_XLOGDIR"
-		fi
-		eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
 
-		# unset/cleanup "nss_wrapper" bits
-		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
-			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
-			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
-		fi
+# print large warning if POSTGRES_PASSWORD is empty
+docker_verify_minimum_env() {
+	# check password first so we can output the warning before postgres
+	# messes it up
+	if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
+		cat >&2 <<-'EOWARN'
 
-		# check password first so we can output the warning before postgres
-		# messes it up
-		if [ -n "$POSTGRES_PASSWORD" ]; then
-			authMethod=md5
+			WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
 
-			if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
-				cat >&2 <<-'EOWARN'
+			  This will not work if used via PGPASSWORD with "psql".
 
-					WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
+			  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
+			  https://github.com/docker-library/postgres/issues/507
 
-					  This will not work if used via PGPASSWORD with "psql".
+		EOWARN
+	fi
+	if [ -z "$POSTGRES_PASSWORD" ]; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+			****************************************************
+			WARNING: No password has been set for the database.
+			         This will allow anyone with access to the
+			         Postgres port to access your database. In
+			         Docker's default configuration, this is
+			         effectively any other container on the same
+			         system.
 
-					  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
-					  https://github.com/docker-library/postgres/issues/507
+			         Use "-e POSTGRES_PASSWORD=password" to set
+			         it in "docker run".
+			****************************************************
+		EOWARN
 
-				EOWARN
-			fi
-		else
-			# The - option suppresses leading tabs but *not* spaces. :)
-			cat >&2 <<-'EOWARN'
-				****************************************************
-				WARNING: No password has been set for the database.
-				         This will allow anyone with access to the
-				         Postgres port to access your database. In
-				         Docker's default configuration, this is
-				         effectively any other container on the same
-				         system.
+	fi
+}
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
-				****************************************************
-			EOWARN
+# usage: docker_process_init_files [file [file [...]]]
+#    ie: docker_process_init_files /always-initdb.d/*
+# process initializer files, based on file extensions and permissions
+docker_process_init_files() {
+	# psql here for backwards compatiblilty "${psql[@]}"
+	psql=( docker_process_sql )
 
-			authMethod=trust
-		fi
-
-		{
-			echo
-			echo "host all all all $authMethod"
-		} >> "$PGDATA/pg_hba.conf"
-
-		# internal start of server in order to allow set-up using psql-client
-		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
-
-		file_env 'POSTGRES_DB' "$POSTGRES_USER"
-
-		export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
-		psql=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
-
-		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			"${psql[@]}" --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
-				CREATE DATABASE :"db" ;
-			EOSQL
-			echo
-		fi
-		psql+=( --dbname "$POSTGRES_DB" )
-
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					echo "$0: running $f"
+					"$f"
+				else
+					echo "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
+			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*)        echo "$0: ignoring $f" ;;
+		esac
 		echo
-		for f in /docker-entrypoint-initdb.d/*; do
-			case "$f" in
-				*.sh)
-					# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
-					# https://github.com/docker-library/postgres/pull/452
-					if [ -x "$f" ]; then
-						echo "$0: running $f"
-						"$f"
-					else
-						echo "$0: sourcing $f"
-						. "$f"
-					fi
-					;;
-				*.sql)    echo "$0: running $f"; "${psql[@]}" -f "$f"; echo ;;
-				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${psql[@]}"; echo ;;
-				*)        echo "$0: ignoring $f" ;;
-			esac
-			echo
-		done
+	done
+}
 
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" -m fast -w stop
+# Execute sql script, passed via stdin (or -f flag of pqsl)
+# usage: docker_process_sql [psql-cli-args]
+#    ie: docker_process_sql --dbname=mydb <<<'INSERT ...'
+#    ie: docker_process_sql -f my-file.sql
+#    ie: docker_process_sql <my-file.sql
+docker_process_sql() {
+	local query_runner=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
+	if [ -n "$POSTGRES_DB" ]; then
+		query_runner+=( --dbname "$POSTGRES_DB" )
+	fi
 
-		unset PGPASSWORD
+	"${query_runner[@]}" "$@"
+}
 
-		echo
-		echo 'PostgreSQL init process complete; ready for start up.'
+# create initial database
+# uses environment variables for input: POSTGRES_DB
+docker_setup_db() {
+	if [ "$POSTGRES_DB" != 'postgres' ]; then
+		POSTGRES_DB= docker_process_sql --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
+			CREATE DATABASE :"db" ;
+		EOSQL
 		echo
 	fi
-fi
+}
 
-exec "$@"
+# Loads various settings that are used elsewhere in the script
+# This should be called before any other functions
+docker_setup_env() {
+	file_env 'POSTGRES_PASSWORD'
+
+	file_env 'POSTGRES_USER' 'postgres'
+	file_env 'POSTGRES_DB' "$POSTGRES_USER"
+	file_env 'POSTGRES_INITDB_ARGS'
+
+	declare -g DATABASE_ALREADY_EXISTS
+	# look specifically for PG_VERSION, as it is expected in the DB dir
+	if [ -s "$PGDATA/PG_VERSION" ]; then
+		DATABASE_ALREADY_EXISTS='true'
+	fi
+}
+
+# append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
+pg_setup_hba_conf() {
+	local authMethod
+	if [ "$POSTGRES_PASSWORD" ]; then
+		authMethod='md5'
+	else
+		authMethod='trust'
+	fi
+
+	{
+		echo
+		echo "host all all all $authMethod"
+	} >> "$PGDATA/pg_hba.conf"
+}
+
+# start socket-only postgresql server for setting up or running scripts
+# all arguments will be passed along as arguments to `postgres` (via pg_ctl)
+docker_temp_server_start() {
+	if [ "$1" = 'postgres' ]; then
+		shift
+	fi
+	# internal start of server in order to allow setup using psql client
+	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-w start
+}
+
+# stop postgresql server after done setting up user and running scripts
+docker_temp_server_stop() {
+	PGUSER="${PGUSER:-postgres}" \
+	pg_ctl -D "$PGDATA" -m fast -w stop
+}
+
+_main() {
+	# if first arg looks like a flag, assume we want to run postgres server
+	if [ "${1:0:1}" = '-' ]; then
+		set -- postgres "$@"
+	fi
+
+
+	if [ "$1" = 'postgres' ]; then
+		docker_setup_env
+		# setup data directories and permissions (when run as root)
+		docker_create_db_directories
+		if [ "$(id -u)" = '0' ]; then
+			# then restart script as postgres user
+			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		# only run initialization on an empty data directory
+		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+			docker_verify_minimum_env
+			docker_init_database_dir
+			pg_setup_hba_conf
+
+			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+			# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+			export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+			docker_temp_server_start "$@"
+
+			docker_setup_db
+			docker_process_init_files /docker-entrypoint-initdb.d/*
+
+			docker_temp_server_stop
+			unset PGPASSWORD
+
+			echo
+			echo 'PostgreSQL init process complete; ready for start up.'
+			echo
+		else
+			echo
+			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
+			echo
+		fi
+	fi
+
+	exec "$@"
+}
+
+if ! _is_sourced; then
+	_main "$@"
+fi

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -24,153 +24,254 @@ file_env() {
 	unset "$fileVar"
 }
 
-if [ "${1:0:1}" = '-' ]; then
-	set -- postgres "$@"
-fi
+# check to see if this file is being run or sourced from another script
+_is_sourced() {
+	# https://unix.stackexchange.com/a/215279
+	[ "${#FUNCNAME[@]}" -ge 2 ] \
+		&& [ "${FUNCNAME[0]}" = '_is_sourced' ] \
+		&& [ "${FUNCNAME[1]}" = 'source' ]
+}
 
-# allow the container to be started with `--user`
-if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
+# used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
+docker_create_db_directories() {
+	local user="$(id -u)"
+
 	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
 
-	mkdir -p /var/run/postgresql
-	chown -R postgres /var/run/postgresql
-	chmod 775 /var/run/postgresql
+	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
+	mkdir -p /var/run/postgresql || :
+	chmod 775 /var/run/postgresql || :
 
-	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
+	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_XLOGDIR"
-		chown -R postgres "$POSTGRES_INITDB_XLOGDIR"
+		[ "$user" = '0' ] && find "$POSTGRES_INITDB_XLOGDIR" \! -user postgres - exec chown postgres '{}' +
 		chmod 700 "$POSTGRES_INITDB_XLOGDIR"
 	fi
 
-	exec gosu postgres "$BASH_SOURCE" "$@"
-fi
+	# allow the container to be started with `--user`
+	if [ "$user" = '0' ]; then
+		find "$PGDATA" \! -user postgres -exec chown postgres '{}' +
+		find /var/run/postgresql \! -user postgres -exec chown postgres '{}' +
+	fi
+}
 
-if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+# initialize empty PGDATA directory with new database via 'initdb'
+# arguments to `initdb` can be passed via POSTGRES_INITDB_ARGS or as arguments to this function
+# `initdb` automatically creates the "postgres", "template0", and "template1" dbnames
+# this is also where the database user is created, specified by `POSTGRES_USER` env
+docker_init_database_dir() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
 
-	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ ! -s "$PGDATA/PG_VERSION" ]; then
-		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
-		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
-		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
-			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
-			export NSS_WRAPPER_PASSWD="$(mktemp)"
-			export NSS_WRAPPER_GROUP="$(mktemp)"
-			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
-			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
-		fi
+	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+		set -- --xlogdir "$POSTGRES_INITDB_XLOGDIR" "$@"
+	fi
 
-		file_env 'POSTGRES_USER' 'postgres'
-		file_env 'POSTGRES_PASSWORD'
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
 
-		file_env 'POSTGRES_INITDB_ARGS'
-		if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
-			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --xlogdir $POSTGRES_INITDB_XLOGDIR"
-		fi
-		eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
 
-		# unset/cleanup "nss_wrapper" bits
-		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
-			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
-			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
-		fi
+# print large warning if POSTGRES_PASSWORD is empty
+docker_verify_minimum_env() {
+	# check password first so we can output the warning before postgres
+	# messes it up
+	if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
+		cat >&2 <<-'EOWARN'
 
-		# check password first so we can output the warning before postgres
-		# messes it up
-		if [ -n "$POSTGRES_PASSWORD" ]; then
-			authMethod=md5
+			WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
 
-			if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
-				cat >&2 <<-'EOWARN'
+			  This will not work if used via PGPASSWORD with "psql".
 
-					WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
+			  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
+			  https://github.com/docker-library/postgres/issues/507
 
-					  This will not work if used via PGPASSWORD with "psql".
+		EOWARN
+	fi
+	if [ -z "$POSTGRES_PASSWORD" ]; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+			****************************************************
+			WARNING: No password has been set for the database.
+			         This will allow anyone with access to the
+			         Postgres port to access your database. In
+			         Docker's default configuration, this is
+			         effectively any other container on the same
+			         system.
 
-					  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
-					  https://github.com/docker-library/postgres/issues/507
+			         Use "-e POSTGRES_PASSWORD=password" to set
+			         it in "docker run".
+			****************************************************
+		EOWARN
 
-				EOWARN
-			fi
-		else
-			# The - option suppresses leading tabs but *not* spaces. :)
-			cat >&2 <<-'EOWARN'
-				****************************************************
-				WARNING: No password has been set for the database.
-				         This will allow anyone with access to the
-				         Postgres port to access your database. In
-				         Docker's default configuration, this is
-				         effectively any other container on the same
-				         system.
+	fi
+}
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
-				****************************************************
-			EOWARN
+# usage: docker_process_init_files [file [file [...]]]
+#    ie: docker_process_init_files /always-initdb.d/*
+# process initializer files, based on file extensions and permissions
+docker_process_init_files() {
+	# psql here for backwards compatiblilty "${psql[@]}"
+	psql=( docker_process_sql )
 
-			authMethod=trust
-		fi
-
-		{
-			echo
-			echo "host all all all $authMethod"
-		} >> "$PGDATA/pg_hba.conf"
-
-		# internal start of server in order to allow set-up using psql-client
-		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
-
-		file_env 'POSTGRES_DB' "$POSTGRES_USER"
-
-		export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
-		psql=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
-
-		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			"${psql[@]}" --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
-				CREATE DATABASE :"db" ;
-			EOSQL
-			echo
-		fi
-		psql+=( --dbname "$POSTGRES_DB" )
-
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					echo "$0: running $f"
+					"$f"
+				else
+					echo "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
+			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*)        echo "$0: ignoring $f" ;;
+		esac
 		echo
-		for f in /docker-entrypoint-initdb.d/*; do
-			case "$f" in
-				*.sh)
-					# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
-					# https://github.com/docker-library/postgres/pull/452
-					if [ -x "$f" ]; then
-						echo "$0: running $f"
-						"$f"
-					else
-						echo "$0: sourcing $f"
-						. "$f"
-					fi
-					;;
-				*.sql)    echo "$0: running $f"; "${psql[@]}" -f "$f"; echo ;;
-				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${psql[@]}"; echo ;;
-				*)        echo "$0: ignoring $f" ;;
-			esac
-			echo
-		done
+	done
+}
 
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" -m fast -w stop
+# Execute sql script, passed via stdin (or -f flag of pqsl)
+# usage: docker_process_sql [psql-cli-args]
+#    ie: docker_process_sql --dbname=mydb <<<'INSERT ...'
+#    ie: docker_process_sql -f my-file.sql
+#    ie: docker_process_sql <my-file.sql
+docker_process_sql() {
+	local query_runner=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
+	if [ -n "$POSTGRES_DB" ]; then
+		query_runner+=( --dbname "$POSTGRES_DB" )
+	fi
 
-		unset PGPASSWORD
+	"${query_runner[@]}" "$@"
+}
 
-		echo
-		echo 'PostgreSQL init process complete; ready for start up.'
+# create initial database
+# uses environment variables for input: POSTGRES_DB
+docker_setup_db() {
+	if [ "$POSTGRES_DB" != 'postgres' ]; then
+		POSTGRES_DB= docker_process_sql --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
+			CREATE DATABASE :"db" ;
+		EOSQL
 		echo
 	fi
-fi
+}
 
-exec "$@"
+# Loads various settings that are used elsewhere in the script
+# This should be called before any other functions
+docker_setup_env() {
+	file_env 'POSTGRES_PASSWORD'
+
+	file_env 'POSTGRES_USER' 'postgres'
+	file_env 'POSTGRES_DB' "$POSTGRES_USER"
+	file_env 'POSTGRES_INITDB_ARGS'
+
+	declare -g DATABASE_ALREADY_EXISTS
+	# look specifically for PG_VERSION, as it is expected in the DB dir
+	if [ -s "$PGDATA/PG_VERSION" ]; then
+		DATABASE_ALREADY_EXISTS='true'
+	fi
+}
+
+# append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
+pg_setup_hba_conf() {
+	local authMethod
+	if [ "$POSTGRES_PASSWORD" ]; then
+		authMethod='md5'
+	else
+		authMethod='trust'
+	fi
+
+	{
+		echo
+		echo "host all all all $authMethod"
+	} >> "$PGDATA/pg_hba.conf"
+}
+
+# start socket-only postgresql server for setting up or running scripts
+# all arguments will be passed along as arguments to `postgres` (via pg_ctl)
+docker_temp_server_start() {
+	if [ "$1" = 'postgres' ]; then
+		shift
+	fi
+	# internal start of server in order to allow setup using psql client
+	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-w start
+}
+
+# stop postgresql server after done setting up user and running scripts
+docker_temp_server_stop() {
+	PGUSER="${PGUSER:-postgres}" \
+	pg_ctl -D "$PGDATA" -m fast -w stop
+}
+
+_main() {
+	# if first arg looks like a flag, assume we want to run postgres server
+	if [ "${1:0:1}" = '-' ]; then
+		set -- postgres "$@"
+	fi
+
+
+	if [ "$1" = 'postgres' ]; then
+		docker_setup_env
+		# setup data directories and permissions (when run as root)
+		docker_create_db_directories
+		if [ "$(id -u)" = '0' ]; then
+			# then restart script as postgres user
+			exec gosu postgres "$BASH_SOURCE" "$@"
+		fi
+
+		# only run initialization on an empty data directory
+		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+			docker_verify_minimum_env
+			docker_init_database_dir
+			pg_setup_hba_conf
+
+			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+			# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+			export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+			docker_temp_server_start "$@"
+
+			docker_setup_db
+			docker_process_init_files /docker-entrypoint-initdb.d/*
+
+			docker_temp_server_stop
+			unset PGPASSWORD
+
+			echo
+			echo 'PostgreSQL init process complete; ready for start up.'
+			echo
+		else
+			echo
+			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
+			echo
+		fi
+	fi
+
+	exec "$@"
+}
+
+if ! _is_sourced; then
+	_main "$@"
+fi

--- a/9.6/alpine/docker-entrypoint.sh
+++ b/9.6/alpine/docker-entrypoint.sh
@@ -24,153 +24,254 @@ file_env() {
 	unset "$fileVar"
 }
 
-if [ "${1:0:1}" = '-' ]; then
-	set -- postgres "$@"
-fi
+# check to see if this file is being run or sourced from another script
+_is_sourced() {
+	# https://unix.stackexchange.com/a/215279
+	[ "${#FUNCNAME[@]}" -ge 2 ] \
+		&& [ "${FUNCNAME[0]}" = '_is_sourced' ] \
+		&& [ "${FUNCNAME[1]}" = 'source' ]
+}
 
-# allow the container to be started with `--user`
-if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
+# used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
+docker_create_db_directories() {
+	local user="$(id -u)"
+
 	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
 
-	mkdir -p /var/run/postgresql
-	chown -R postgres /var/run/postgresql
-	chmod 775 /var/run/postgresql
+	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
+	mkdir -p /var/run/postgresql || :
+	chmod 775 /var/run/postgresql || :
 
-	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
+	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_XLOGDIR"
-		chown -R postgres "$POSTGRES_INITDB_XLOGDIR"
+		[ "$user" = '0' ] && find "$POSTGRES_INITDB_XLOGDIR" \! -user postgres - exec chown postgres '{}' +
 		chmod 700 "$POSTGRES_INITDB_XLOGDIR"
 	fi
 
-	exec su-exec postgres "$BASH_SOURCE" "$@"
-fi
+	# allow the container to be started with `--user`
+	if [ "$user" = '0' ]; then
+		find "$PGDATA" \! -user postgres -exec chown postgres '{}' +
+		find /var/run/postgresql \! -user postgres -exec chown postgres '{}' +
+	fi
+}
 
-if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+# initialize empty PGDATA directory with new database via 'initdb'
+# arguments to `initdb` can be passed via POSTGRES_INITDB_ARGS or as arguments to this function
+# `initdb` automatically creates the "postgres", "template0", and "template1" dbnames
+# this is also where the database user is created, specified by `POSTGRES_USER` env
+docker_init_database_dir() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
 
-	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ ! -s "$PGDATA/PG_VERSION" ]; then
-		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
-		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
-		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
-			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
-			export NSS_WRAPPER_PASSWD="$(mktemp)"
-			export NSS_WRAPPER_GROUP="$(mktemp)"
-			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
-			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
-		fi
+	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+		set -- --xlogdir "$POSTGRES_INITDB_XLOGDIR" "$@"
+	fi
 
-		file_env 'POSTGRES_USER' 'postgres'
-		file_env 'POSTGRES_PASSWORD'
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
 
-		file_env 'POSTGRES_INITDB_ARGS'
-		if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
-			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --xlogdir $POSTGRES_INITDB_XLOGDIR"
-		fi
-		eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
 
-		# unset/cleanup "nss_wrapper" bits
-		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
-			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
-			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
-		fi
+# print large warning if POSTGRES_PASSWORD is empty
+docker_verify_minimum_env() {
+	# check password first so we can output the warning before postgres
+	# messes it up
+	if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
+		cat >&2 <<-'EOWARN'
 
-		# check password first so we can output the warning before postgres
-		# messes it up
-		if [ -n "$POSTGRES_PASSWORD" ]; then
-			authMethod=md5
+			WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
 
-			if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
-				cat >&2 <<-'EOWARN'
+			  This will not work if used via PGPASSWORD with "psql".
 
-					WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
+			  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
+			  https://github.com/docker-library/postgres/issues/507
 
-					  This will not work if used via PGPASSWORD with "psql".
+		EOWARN
+	fi
+	if [ -z "$POSTGRES_PASSWORD" ]; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+			****************************************************
+			WARNING: No password has been set for the database.
+			         This will allow anyone with access to the
+			         Postgres port to access your database. In
+			         Docker's default configuration, this is
+			         effectively any other container on the same
+			         system.
 
-					  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
-					  https://github.com/docker-library/postgres/issues/507
+			         Use "-e POSTGRES_PASSWORD=password" to set
+			         it in "docker run".
+			****************************************************
+		EOWARN
 
-				EOWARN
-			fi
-		else
-			# The - option suppresses leading tabs but *not* spaces. :)
-			cat >&2 <<-'EOWARN'
-				****************************************************
-				WARNING: No password has been set for the database.
-				         This will allow anyone with access to the
-				         Postgres port to access your database. In
-				         Docker's default configuration, this is
-				         effectively any other container on the same
-				         system.
+	fi
+}
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
-				****************************************************
-			EOWARN
+# usage: docker_process_init_files [file [file [...]]]
+#    ie: docker_process_init_files /always-initdb.d/*
+# process initializer files, based on file extensions and permissions
+docker_process_init_files() {
+	# psql here for backwards compatiblilty "${psql[@]}"
+	psql=( docker_process_sql )
 
-			authMethod=trust
-		fi
-
-		{
-			echo
-			echo "host all all all $authMethod"
-		} >> "$PGDATA/pg_hba.conf"
-
-		# internal start of server in order to allow set-up using psql-client
-		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
-
-		file_env 'POSTGRES_DB' "$POSTGRES_USER"
-
-		export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
-		psql=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
-
-		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			"${psql[@]}" --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
-				CREATE DATABASE :"db" ;
-			EOSQL
-			echo
-		fi
-		psql+=( --dbname "$POSTGRES_DB" )
-
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					echo "$0: running $f"
+					"$f"
+				else
+					echo "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
+			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*)        echo "$0: ignoring $f" ;;
+		esac
 		echo
-		for f in /docker-entrypoint-initdb.d/*; do
-			case "$f" in
-				*.sh)
-					# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
-					# https://github.com/docker-library/postgres/pull/452
-					if [ -x "$f" ]; then
-						echo "$0: running $f"
-						"$f"
-					else
-						echo "$0: sourcing $f"
-						. "$f"
-					fi
-					;;
-				*.sql)    echo "$0: running $f"; "${psql[@]}" -f "$f"; echo ;;
-				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${psql[@]}"; echo ;;
-				*)        echo "$0: ignoring $f" ;;
-			esac
-			echo
-		done
+	done
+}
 
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" -m fast -w stop
+# Execute sql script, passed via stdin (or -f flag of pqsl)
+# usage: docker_process_sql [psql-cli-args]
+#    ie: docker_process_sql --dbname=mydb <<<'INSERT ...'
+#    ie: docker_process_sql -f my-file.sql
+#    ie: docker_process_sql <my-file.sql
+docker_process_sql() {
+	local query_runner=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
+	if [ -n "$POSTGRES_DB" ]; then
+		query_runner+=( --dbname "$POSTGRES_DB" )
+	fi
 
-		unset PGPASSWORD
+	"${query_runner[@]}" "$@"
+}
 
-		echo
-		echo 'PostgreSQL init process complete; ready for start up.'
+# create initial database
+# uses environment variables for input: POSTGRES_DB
+docker_setup_db() {
+	if [ "$POSTGRES_DB" != 'postgres' ]; then
+		POSTGRES_DB= docker_process_sql --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
+			CREATE DATABASE :"db" ;
+		EOSQL
 		echo
 	fi
-fi
+}
 
-exec "$@"
+# Loads various settings that are used elsewhere in the script
+# This should be called before any other functions
+docker_setup_env() {
+	file_env 'POSTGRES_PASSWORD'
+
+	file_env 'POSTGRES_USER' 'postgres'
+	file_env 'POSTGRES_DB' "$POSTGRES_USER"
+	file_env 'POSTGRES_INITDB_ARGS'
+
+	declare -g DATABASE_ALREADY_EXISTS
+	# look specifically for PG_VERSION, as it is expected in the DB dir
+	if [ -s "$PGDATA/PG_VERSION" ]; then
+		DATABASE_ALREADY_EXISTS='true'
+	fi
+}
+
+# append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
+pg_setup_hba_conf() {
+	local authMethod
+	if [ "$POSTGRES_PASSWORD" ]; then
+		authMethod='md5'
+	else
+		authMethod='trust'
+	fi
+
+	{
+		echo
+		echo "host all all all $authMethod"
+	} >> "$PGDATA/pg_hba.conf"
+}
+
+# start socket-only postgresql server for setting up or running scripts
+# all arguments will be passed along as arguments to `postgres` (via pg_ctl)
+docker_temp_server_start() {
+	if [ "$1" = 'postgres' ]; then
+		shift
+	fi
+	# internal start of server in order to allow setup using psql client
+	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-w start
+}
+
+# stop postgresql server after done setting up user and running scripts
+docker_temp_server_stop() {
+	PGUSER="${PGUSER:-postgres}" \
+	pg_ctl -D "$PGDATA" -m fast -w stop
+}
+
+_main() {
+	# if first arg looks like a flag, assume we want to run postgres server
+	if [ "${1:0:1}" = '-' ]; then
+		set -- postgres "$@"
+	fi
+
+
+	if [ "$1" = 'postgres' ]; then
+		docker_setup_env
+		# setup data directories and permissions (when run as root)
+		docker_create_db_directories
+		if [ "$(id -u)" = '0' ]; then
+			# then restart script as postgres user
+			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		# only run initialization on an empty data directory
+		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+			docker_verify_minimum_env
+			docker_init_database_dir
+			pg_setup_hba_conf
+
+			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+			# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+			export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+			docker_temp_server_start "$@"
+
+			docker_setup_db
+			docker_process_init_files /docker-entrypoint-initdb.d/*
+
+			docker_temp_server_stop
+			unset PGPASSWORD
+
+			echo
+			echo 'PostgreSQL init process complete; ready for start up.'
+			echo
+		else
+			echo
+			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
+			echo
+		fi
+	fi
+
+	exec "$@"
+}
+
+if ! _is_sourced; then
+	_main "$@"
+fi

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -24,153 +24,254 @@ file_env() {
 	unset "$fileVar"
 }
 
-if [ "${1:0:1}" = '-' ]; then
-	set -- postgres "$@"
-fi
+# check to see if this file is being run or sourced from another script
+_is_sourced() {
+	# https://unix.stackexchange.com/a/215279
+	[ "${#FUNCNAME[@]}" -ge 2 ] \
+		&& [ "${FUNCNAME[0]}" = '_is_sourced' ] \
+		&& [ "${FUNCNAME[1]}" = 'source' ]
+}
 
-# allow the container to be started with `--user`
-if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
+# used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
+docker_create_db_directories() {
+	local user="$(id -u)"
+
 	mkdir -p "$PGDATA"
-	chown -R postgres "$PGDATA"
 	chmod 700 "$PGDATA"
 
-	mkdir -p /var/run/postgresql
-	chown -R postgres /var/run/postgresql
-	chmod 775 /var/run/postgresql
+	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
+	mkdir -p /var/run/postgresql || :
+	chmod 775 /var/run/postgresql || :
 
-	# Create the transaction log directory before initdb is run (below) so the directory is owned by the correct user
+	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_XLOGDIR"
-		chown -R postgres "$POSTGRES_INITDB_XLOGDIR"
+		[ "$user" = '0' ] && find "$POSTGRES_INITDB_XLOGDIR" \! -user postgres - exec chown postgres '{}' +
 		chmod 700 "$POSTGRES_INITDB_XLOGDIR"
 	fi
 
-	exec gosu postgres "$BASH_SOURCE" "$@"
-fi
+	# allow the container to be started with `--user`
+	if [ "$user" = '0' ]; then
+		find "$PGDATA" \! -user postgres -exec chown postgres '{}' +
+		find /var/run/postgresql \! -user postgres -exec chown postgres '{}' +
+	fi
+}
 
-if [ "$1" = 'postgres' ]; then
-	mkdir -p "$PGDATA"
-	chown -R "$(id -u)" "$PGDATA" 2>/dev/null || :
-	chmod 700 "$PGDATA" 2>/dev/null || :
+# initialize empty PGDATA directory with new database via 'initdb'
+# arguments to `initdb` can be passed via POSTGRES_INITDB_ARGS or as arguments to this function
+# `initdb` automatically creates the "postgres", "template0", and "template1" dbnames
+# this is also where the database user is created, specified by `POSTGRES_USER` env
+docker_init_database_dir() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
 
-	# look specifically for PG_VERSION, as it is expected in the DB dir
-	if [ ! -s "$PGDATA/PG_VERSION" ]; then
-		# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
-		# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
-		if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
-			export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
-			export NSS_WRAPPER_PASSWD="$(mktemp)"
-			export NSS_WRAPPER_GROUP="$(mktemp)"
-			echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
-			echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
-		fi
+	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+		set -- --xlogdir "$POSTGRES_INITDB_XLOGDIR" "$@"
+	fi
 
-		file_env 'POSTGRES_USER' 'postgres'
-		file_env 'POSTGRES_PASSWORD'
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
 
-		file_env 'POSTGRES_INITDB_ARGS'
-		if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
-			export POSTGRES_INITDB_ARGS="$POSTGRES_INITDB_ARGS --xlogdir $POSTGRES_INITDB_XLOGDIR"
-		fi
-		eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
 
-		# unset/cleanup "nss_wrapper" bits
-		if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
-			rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
-			unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
-		fi
+# print large warning if POSTGRES_PASSWORD is empty
+docker_verify_minimum_env() {
+	# check password first so we can output the warning before postgres
+	# messes it up
+	if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
+		cat >&2 <<-'EOWARN'
 
-		# check password first so we can output the warning before postgres
-		# messes it up
-		if [ -n "$POSTGRES_PASSWORD" ]; then
-			authMethod=md5
+			WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
 
-			if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
-				cat >&2 <<-'EOWARN'
+			  This will not work if used via PGPASSWORD with "psql".
 
-					WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
+			  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
+			  https://github.com/docker-library/postgres/issues/507
 
-					  This will not work if used via PGPASSWORD with "psql".
+		EOWARN
+	fi
+	if [ -z "$POSTGRES_PASSWORD" ]; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+			****************************************************
+			WARNING: No password has been set for the database.
+			         This will allow anyone with access to the
+			         Postgres port to access your database. In
+			         Docker's default configuration, this is
+			         effectively any other container on the same
+			         system.
 
-					  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
-					  https://github.com/docker-library/postgres/issues/507
+			         Use "-e POSTGRES_PASSWORD=password" to set
+			         it in "docker run".
+			****************************************************
+		EOWARN
 
-				EOWARN
-			fi
-		else
-			# The - option suppresses leading tabs but *not* spaces. :)
-			cat >&2 <<-'EOWARN'
-				****************************************************
-				WARNING: No password has been set for the database.
-				         This will allow anyone with access to the
-				         Postgres port to access your database. In
-				         Docker's default configuration, this is
-				         effectively any other container on the same
-				         system.
+	fi
+}
 
-				         Use "-e POSTGRES_PASSWORD=password" to set
-				         it in "docker run".
-				****************************************************
-			EOWARN
+# usage: docker_process_init_files [file [file [...]]]
+#    ie: docker_process_init_files /always-initdb.d/*
+# process initializer files, based on file extensions and permissions
+docker_process_init_files() {
+	# psql here for backwards compatiblilty "${psql[@]}"
+	psql=( docker_process_sql )
 
-			authMethod=trust
-		fi
-
-		{
-			echo
-			echo "host all all all $authMethod"
-		} >> "$PGDATA/pg_hba.conf"
-
-		# internal start of server in order to allow set-up using psql-client
-		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
-
-		file_env 'POSTGRES_DB' "$POSTGRES_USER"
-
-		export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
-		psql=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
-
-		if [ "$POSTGRES_DB" != 'postgres' ]; then
-			"${psql[@]}" --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
-				CREATE DATABASE :"db" ;
-			EOSQL
-			echo
-		fi
-		psql+=( --dbname "$POSTGRES_DB" )
-
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					echo "$0: running $f"
+					"$f"
+				else
+					echo "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
+			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*)        echo "$0: ignoring $f" ;;
+		esac
 		echo
-		for f in /docker-entrypoint-initdb.d/*; do
-			case "$f" in
-				*.sh)
-					# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
-					# https://github.com/docker-library/postgres/pull/452
-					if [ -x "$f" ]; then
-						echo "$0: running $f"
-						"$f"
-					else
-						echo "$0: sourcing $f"
-						. "$f"
-					fi
-					;;
-				*.sql)    echo "$0: running $f"; "${psql[@]}" -f "$f"; echo ;;
-				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${psql[@]}"; echo ;;
-				*)        echo "$0: ignoring $f" ;;
-			esac
-			echo
-		done
+	done
+}
 
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" -m fast -w stop
+# Execute sql script, passed via stdin (or -f flag of pqsl)
+# usage: docker_process_sql [psql-cli-args]
+#    ie: docker_process_sql --dbname=mydb <<<'INSERT ...'
+#    ie: docker_process_sql -f my-file.sql
+#    ie: docker_process_sql <my-file.sql
+docker_process_sql() {
+	local query_runner=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password )
+	if [ -n "$POSTGRES_DB" ]; then
+		query_runner+=( --dbname "$POSTGRES_DB" )
+	fi
 
-		unset PGPASSWORD
+	"${query_runner[@]}" "$@"
+}
 
-		echo
-		echo 'PostgreSQL init process complete; ready for start up.'
+# create initial database
+# uses environment variables for input: POSTGRES_DB
+docker_setup_db() {
+	if [ "$POSTGRES_DB" != 'postgres' ]; then
+		POSTGRES_DB= docker_process_sql --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
+			CREATE DATABASE :"db" ;
+		EOSQL
 		echo
 	fi
-fi
+}
 
-exec "$@"
+# Loads various settings that are used elsewhere in the script
+# This should be called before any other functions
+docker_setup_env() {
+	file_env 'POSTGRES_PASSWORD'
+
+	file_env 'POSTGRES_USER' 'postgres'
+	file_env 'POSTGRES_DB' "$POSTGRES_USER"
+	file_env 'POSTGRES_INITDB_ARGS'
+
+	declare -g DATABASE_ALREADY_EXISTS
+	# look specifically for PG_VERSION, as it is expected in the DB dir
+	if [ -s "$PGDATA/PG_VERSION" ]; then
+		DATABASE_ALREADY_EXISTS='true'
+	fi
+}
+
+# append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
+pg_setup_hba_conf() {
+	local authMethod
+	if [ "$POSTGRES_PASSWORD" ]; then
+		authMethod='md5'
+	else
+		authMethod='trust'
+	fi
+
+	{
+		echo
+		echo "host all all all $authMethod"
+	} >> "$PGDATA/pg_hba.conf"
+}
+
+# start socket-only postgresql server for setting up or running scripts
+# all arguments will be passed along as arguments to `postgres` (via pg_ctl)
+docker_temp_server_start() {
+	if [ "$1" = 'postgres' ]; then
+		shift
+	fi
+	# internal start of server in order to allow setup using psql client
+	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-w start
+}
+
+# stop postgresql server after done setting up user and running scripts
+docker_temp_server_stop() {
+	PGUSER="${PGUSER:-postgres}" \
+	pg_ctl -D "$PGDATA" -m fast -w stop
+}
+
+_main() {
+	# if first arg looks like a flag, assume we want to run postgres server
+	if [ "${1:0:1}" = '-' ]; then
+		set -- postgres "$@"
+	fi
+
+
+	if [ "$1" = 'postgres' ]; then
+		docker_setup_env
+		# setup data directories and permissions (when run as root)
+		docker_create_db_directories
+		if [ "$(id -u)" = '0' ]; then
+			# then restart script as postgres user
+			exec gosu postgres "$BASH_SOURCE" "$@"
+		fi
+
+		# only run initialization on an empty data directory
+		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+			docker_verify_minimum_env
+			docker_init_database_dir
+			pg_setup_hba_conf
+
+			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+			# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+			export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+			docker_temp_server_start "$@"
+
+			docker_setup_db
+			docker_process_init_files /docker-entrypoint-initdb.d/*
+
+			docker_temp_server_stop
+			unset PGPASSWORD
+
+			echo
+			echo 'PostgreSQL init process complete; ready for start up.'
+			echo
+		else
+			echo
+			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
+			echo
+		fi
+	fi
+
+	exec "$@"
+}
+
+if ! _is_sourced; then
+	_main "$@"
+fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,7 +27,9 @@ file_env() {
 # check to see if this file is being run or sourced from another script
 _is_sourced() {
 	# https://unix.stackexchange.com/a/215279
-	[ "${FUNCNAME[${#FUNCNAME[@]} - 1]}" == 'source' ]
+	[ "${#FUNCNAME[@]}" -ge 2 ] \
+		&& [ "${FUNCNAME[0]}" = '_is_sourced' ] \
+		&& [ "${FUNCNAME[1]}" = 'source' ]
 }
 
 # used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -34,7 +34,7 @@ _is_sourced() {
 
 # used to create initial posgres directories and if run as root, ensure ownership to the "postgres" user
 docker_create_db_directories() {
-	local user="$(id -u)"
+	local user; user="$(id -u)"
 
 	mkdir -p "$PGDATA"
 	chmod 700 "$PGDATA"
@@ -46,7 +46,9 @@ docker_create_db_directories() {
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
 	if [ "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
-		[ "$user" = '0' ] && find "$POSTGRES_INITDB_WALDIR" \! -user postgres - exec chown postgres '{}' +
+		if [ "$user" = '0' ]; then
+			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
+		fi
 		chmod 700 "$POSTGRES_INITDB_WALDIR"
 	fi
 
@@ -193,10 +195,8 @@ docker_setup_env() {
 
 # append md5 or trust auth to pg_hba.conf based on existence of POSTGRES_PASSWORD
 pg_setup_hba_conf() {
-	local authMethod
-	if [ "$POSTGRES_PASSWORD" ]; then
-		authMethod='md5'
-	else
+	local authMethod='md5'
+	if [ -z "$POSTGRES_PASSWORD" ]; then
 		authMethod='trust'
 	fi
 
@@ -231,7 +231,6 @@ _main() {
 	if [ "${1:0:1}" = '-' ]; then
 		set -- postgres "$@"
 	fi
-
 
 	if [ "$1" = 'postgres' ]; then
 		docker_setup_env


### PR DESCRIPTION
This will allow a user to write a script to use our script as a base for their own postgres startup.

We need to ensure that that we define the set of functions that users can call. Currently that is any function that doesn't start with an underscore (listed below):

```bash
file_env
# create_postgres_dirs
docker_create_db_directories
# init_pgdata
docker_init_database_dir
docker_verify_minimum_env
docker_process_init_files
docker_process_sql
docker_setup_db
docker_setup_env
pg_setup_hba_conf
docker_temp_server_start
docker_temp_server_stop
```

-------------------------------------

EDIT: example updated (and tested) with an example `docker run`.

Here is an example using the current interface to run other init scripts on every start:
```bash
#!/usr/bin/env bash
set -Eeo pipefail

# Example using the functions of the postgres entrypoint to customize startup to always run files in /always-initdb.d/

source "$(which docker-entrypoint.sh)"

docker_setup_env
docker_create_db_directories
# assumption: we are already running as the owner of PGDATA

# This is needed if the container is started as `root`
#if [ "$1" = 'postgres' ] && [ "$(id -u)" = '0' ]; then
#	exec gosu postgres "$BASH_SOURCE" "$@"
#fi

if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
	docker_verify_minimum_env
	docker_init_database_dir
	pg_setup_hba_conf
	
	# only required for '--auth[-local]=md5' on POSTGRES_INITDB_ARGS
	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
	
	docker_temp_server_start "$@" -c max_locks_per_transaction=256
	docker_setup_db
	docker_process_init_files /docker-entrypoint-initdb.d/*
	docker_temp_server_stop
else
	docker_temp_server_start "$@"
	docker_process_init_files /always-initdb.d/*
	docker_temp_server_stop
fi

exec postgres "$@"
```

```console
$ docker run -it --rm \
  -e POSTGRES_PASSWORD=12345 \
  -v "$PWD/custom-entrypoint.sh":/usr/local/bin/custom-entrypoint.sh \
  -v "$PWD/docker-entrypoint-initdb.d/":/docker-entrypoint-initdb.d/ \
  -v "$PWD/always-initdb.d/":/always-initdb.d/ \
  -v "$PWD/data/":/var/lib/postgresql/data/ \
  --name=pg --user=1000 \
  postgres:11-test custom-entrypoint.sh -c 'max_locks_per_transaction=512'
```

-------------------------------

Closes #463, closes #461

EDIT: Threading the needle; related to https://github.com/docker-library/rabbitmq/pull/281
EDIT: applied new function names from discussion and nearing completion of https://github.com/docker-library/mysql/pull/471 (rebased commits incoming) 