### PR TITLE
Add POSTGRES_SETUP_ARGS for setup configuration

### DIFF
--- a/10/alpine/docker-entrypoint.sh
+++ b/10/alpine/docker-entrypoint.sh
@@ -110,10 +110,12 @@ if [ "$1" = 'postgres' ]; then
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
+		file_env 'POSTGRES_SETUP_ARGS'
+		eval "PGUSER=\"${PGUSER:-$POSTGRES_USER}\" \
+			pg_ctl -D \"$PGDATA\" \
+			-o \"-c listen_addresses=''\" \
+			$POSTGRES_SETUP_ARGS \
+			-w start"
 
 		file_env 'POSTGRES_DB' "$POSTGRES_USER"
 

--- a/10/docker-entrypoint.sh
+++ b/10/docker-entrypoint.sh
@@ -110,10 +110,12 @@ if [ "$1" = 'postgres' ]; then
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
+		file_env 'POSTGRES_SETUP_ARGS'
+		eval "PGUSER=\"${PGUSER:-$POSTGRES_USER}\" \
+			pg_ctl -D \"$PGDATA\" \
+			-o \"-c listen_addresses=''\" \
+			$POSTGRES_SETUP_ARGS \
+			-w start"
 
 		file_env 'POSTGRES_DB' "$POSTGRES_USER"
 

--- a/11/alpine/docker-entrypoint.sh
+++ b/11/alpine/docker-entrypoint.sh
@@ -110,10 +110,12 @@ if [ "$1" = 'postgres' ]; then
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
+		file_env 'POSTGRES_SETUP_ARGS'
+		eval "PGUSER=\"${PGUSER:-$POSTGRES_USER}\" \
+			pg_ctl -D \"$PGDATA\" \
+			-o \"-c listen_addresses=''\" \
+			$POSTGRES_SETUP_ARGS \
+			-w start"
 
 		file_env 'POSTGRES_DB' "$POSTGRES_USER"
 

--- a/11/docker-entrypoint.sh
+++ b/11/docker-entrypoint.sh
@@ -110,10 +110,12 @@ if [ "$1" = 'postgres' ]; then
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
+		file_env 'POSTGRES_SETUP_ARGS'
+		eval "PGUSER=\"${PGUSER:-$POSTGRES_USER}\" \
+			pg_ctl -D \"$PGDATA\" \
+			-o \"-c listen_addresses=''\" \
+			$POSTGRES_SETUP_ARGS \
+			-w start"
 
 		file_env 'POSTGRES_DB' "$POSTGRES_USER"
 

--- a/9.3/alpine/docker-entrypoint.sh
+++ b/9.3/alpine/docker-entrypoint.sh
@@ -110,10 +110,12 @@ if [ "$1" = 'postgres' ]; then
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
+		file_env 'POSTGRES_SETUP_ARGS'
+		eval "PGUSER=\"${PGUSER:-$POSTGRES_USER}\" \
+			pg_ctl -D \"$PGDATA\" \
+			-o \"-c listen_addresses=''\" \
+			$POSTGRES_SETUP_ARGS \
+			-w start"
 
 		file_env 'POSTGRES_DB' "$POSTGRES_USER"
 

--- a/9.3/docker-entrypoint.sh
+++ b/9.3/docker-entrypoint.sh
@@ -110,10 +110,12 @@ if [ "$1" = 'postgres' ]; then
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
+		file_env 'POSTGRES_SETUP_ARGS'
+		eval "PGUSER=\"${PGUSER:-$POSTGRES_USER}\" \
+			pg_ctl -D \"$PGDATA\" \
+			-o \"-c listen_addresses=''\" \
+			$POSTGRES_SETUP_ARGS \
+			-w start"
 
 		file_env 'POSTGRES_DB' "$POSTGRES_USER"
 

--- a/9.4/alpine/docker-entrypoint.sh
+++ b/9.4/alpine/docker-entrypoint.sh
@@ -110,10 +110,12 @@ if [ "$1" = 'postgres' ]; then
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
+		file_env 'POSTGRES_SETUP_ARGS'
+		eval "PGUSER=\"${PGUSER:-$POSTGRES_USER}\" \
+			pg_ctl -D \"$PGDATA\" \
+			-o \"-c listen_addresses=''\" \
+			$POSTGRES_SETUP_ARGS \
+			-w start"
 
 		file_env 'POSTGRES_DB' "$POSTGRES_USER"
 

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -110,10 +110,12 @@ if [ "$1" = 'postgres' ]; then
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
+		file_env 'POSTGRES_SETUP_ARGS'
+		eval "PGUSER=\"${PGUSER:-$POSTGRES_USER}\" \
+			pg_ctl -D \"$PGDATA\" \
+			-o \"-c listen_addresses=''\" \
+			$POSTGRES_SETUP_ARGS \
+			-w start"
 
 		file_env 'POSTGRES_DB' "$POSTGRES_USER"
 

--- a/9.5/alpine/docker-entrypoint.sh
+++ b/9.5/alpine/docker-entrypoint.sh
@@ -110,10 +110,12 @@ if [ "$1" = 'postgres' ]; then
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
+		file_env 'POSTGRES_SETUP_ARGS'
+		eval "PGUSER=\"${PGUSER:-$POSTGRES_USER}\" \
+			pg_ctl -D \"$PGDATA\" \
+			-o \"-c listen_addresses=''\" \
+			$POSTGRES_SETUP_ARGS \
+			-w start"
 
 		file_env 'POSTGRES_DB' "$POSTGRES_USER"
 

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -110,10 +110,12 @@ if [ "$1" = 'postgres' ]; then
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
+		file_env 'POSTGRES_SETUP_ARGS'
+		eval "PGUSER=\"${PGUSER:-$POSTGRES_USER}\" \
+			pg_ctl -D \"$PGDATA\" \
+			-o \"-c listen_addresses=''\" \
+			$POSTGRES_SETUP_ARGS \
+			-w start"
 
 		file_env 'POSTGRES_DB' "$POSTGRES_USER"
 

--- a/9.6/alpine/docker-entrypoint.sh
+++ b/9.6/alpine/docker-entrypoint.sh
@@ -110,10 +110,12 @@ if [ "$1" = 'postgres' ]; then
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
+		file_env 'POSTGRES_SETUP_ARGS'
+		eval "PGUSER=\"${PGUSER:-$POSTGRES_USER}\" \
+			pg_ctl -D \"$PGDATA\" \
+			-o \"-c listen_addresses=''\" \
+			$POSTGRES_SETUP_ARGS \
+			-w start"
 
 		file_env 'POSTGRES_DB' "$POSTGRES_USER"
 

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -110,10 +110,12 @@ if [ "$1" = 'postgres' ]; then
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
+		file_env 'POSTGRES_SETUP_ARGS'
+		eval "PGUSER=\"${PGUSER:-$POSTGRES_USER}\" \
+			pg_ctl -D \"$PGDATA\" \
+			-o \"-c listen_addresses=''\" \
+			$POSTGRES_SETUP_ARGS \
+			-w start"
 
 		file_env 'POSTGRES_DB' "$POSTGRES_USER"
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -110,10 +110,12 @@ if [ "$1" = 'postgres' ]; then
 
 		# internal start of server in order to allow set-up using psql-client
 		# does not listen on external TCP/IP and waits until start finishes
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "-c listen_addresses=''" \
-			-w start
+		file_env 'POSTGRES_SETUP_ARGS'
+		eval "PGUSER=\"${PGUSER:-$POSTGRES_USER}\" \
+			pg_ctl -D \"$PGDATA\" \
+			-o \"-c listen_addresses=''\" \
+			$POSTGRES_SETUP_ARGS \
+			-w start"
 
 		file_env 'POSTGRES_DB' "$POSTGRES_USER"
 


### PR DESCRIPTION
Set the POSTGRES_SETUP_ARGS environment variable to alter configuration
during setup. Useful for settings like "max_wal_size=4GB" and
"fsync=off" when loading initial data. Example pointing at a config
file:

    POSTGRES_SETUP_ARGS='-o "-c config_file=/etc/postgresql/setup.conf"'