### PR TITLE
entrypoint: Added support for setting AuthMethod

### DIFF
--- a/11/alpine/docker-entrypoint.sh
+++ b/11/alpine/docker-entrypoint.sh
@@ -83,7 +83,8 @@ if [ "$1" = 'postgres' ]; then
 		# check password first so we can output the warning before postgres
 		# messes it up
 		if [ -n "$POSTGRES_PASSWORD" ]; then
-			authMethod=md5
+			file_env 'POSTGRES_AUTH_METHOD'
+			authMethod="${POSTGRES_AUTH_METHOD:-md5}"
 
 			if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
 				cat >&2 <<-'EOWARN'


### PR DESCRIPTION
This change adds support to choose which auth method to use on newly-created database (md5 vs scram-sha-256 (... vs future ones))