### PR TITLE
make docker-entrypoint executable to allow use in ENTRYPOINT

### DIFF
--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -169,6 +169,7 @@ RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PG
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 


### PR DESCRIPTION
`docker build -t postgres:latest`

passes but

`docker run postgres:latest`

fails because `docker-entrypoint.sh` is not made executable after being copied into container