### PR TITLE
update to 11.6-1.pgdg90+1

### DIFF
--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -71,7 +71,7 @@ RUN set -ex; \
 	apt-key list
 
 ENV PG_MAJOR 11
-ENV PG_VERSION 11.5-3.pgdg90+1
+ENV PG_VERSION 11.6-1.pgdg90+1
 
 RUN set -ex; \
 	\


### PR DESCRIPTION
This PR updates the latest version of the docker image for pg 11 to 11.6.

Let me know if I need to do anything extra, or that is not acceptable. 