### PR TITLE
resolves #282: add default healthcheck to dockerfiles

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -172,5 +172,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --timeout=5s CMD pg_isready
+
 EXPOSE 5432
 CMD ["postgres"]

--- a/10/alpine/Dockerfile
+++ b/10/alpine/Dockerfile
@@ -150,5 +150,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --timeout=5s CMD pg_isready
+
 EXPOSE 5432
 CMD ["postgres"]

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -172,5 +172,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --timeout=5s CMD pg_isready
+
 EXPOSE 5432
 CMD ["postgres"]

--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -150,5 +150,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --timeout=5s CMD pg_isready
+
 EXPOSE 5432
 CMD ["postgres"]

--- a/12/Dockerfile
+++ b/12/Dockerfile
@@ -172,5 +172,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --timeout=5s CMD pg_isready
+
 EXPOSE 5432
 CMD ["postgres"]

--- a/12/alpine/Dockerfile
+++ b/12/alpine/Dockerfile
@@ -149,5 +149,7 @@ VOLUME /var/lib/postgresql/data
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --timeout=5s CMD pg_isready
+
 EXPOSE 5432
 CMD ["postgres"]

--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -173,5 +173,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --timeout=5s CMD pg_isready
+
 EXPOSE 5432
 CMD ["postgres"]

--- a/9.4/alpine/Dockerfile
+++ b/9.4/alpine/Dockerfile
@@ -148,5 +148,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --timeout=5s CMD pg_isready
+
 EXPOSE 5432
 CMD ["postgres"]

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -173,5 +173,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --timeout=5s CMD pg_isready
+
 EXPOSE 5432
 CMD ["postgres"]

--- a/9.5/alpine/Dockerfile
+++ b/9.5/alpine/Dockerfile
@@ -148,5 +148,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --timeout=5s CMD pg_isready
+
 EXPOSE 5432
 CMD ["postgres"]

--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -173,5 +173,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --timeout=5s CMD pg_isready
+
 EXPOSE 5432
 CMD ["postgres"]

--- a/9.6/alpine/Dockerfile
+++ b/9.6/alpine/Dockerfile
@@ -148,5 +148,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --timeout=5s CMD pg_isready
+
 EXPOSE 5432
 CMD ["postgres"]

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -150,5 +150,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --timeout=5s CMD pg_isready
+
 EXPOSE 5432
 CMD ["postgres"]

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -173,5 +173,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+HEALTHCHECK --timeout=5s CMD pg_isready
+
 EXPOSE 5432
 CMD ["postgres"]


### PR DESCRIPTION
I didn't see an approach using `pg_isready` when browsing through #282 and other proposed changes, but perhaps someone has already been down this route? 

Probably someone will have input on the actual `HEALTHCHECK` settings to use (e.g. `interval`, `timeout`, `retries`) I can make any requested changes real quick (provided some intentional reason ;)

P.S. The readme told me to look over at https://hub.docker.com/_/postgres?tab=description info on contributing, I might be tired and completely overlooking it, but I didn't actually see anything. Hopefully I've set this up correctly, LMK if theres anything at all desired from a contributor perspective. 