### PR TITLE
Adjust "docker_temp_server_start" to override port for consistent unix socket path

### DIFF
--- a/10/alpine/docker-entrypoint.sh
+++ b/10/alpine/docker-entrypoint.sh
@@ -212,11 +212,14 @@ docker_temp_server_start() {
 	if [ "$1" = 'postgres' ]; then
 		shift
 	fi
+
 	# internal start of server in order to allow setup using psql client
-	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	# does not listen on external TCP/IP and waits until start finishes
+	set -- "$@" -c listen_addresses='' -p 5432
+
 	PGUSER="${PGUSER:-$POSTGRES_USER}" \
 	pg_ctl -D "$PGDATA" \
-		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-o "$(printf '%q ' "$@")" \
 		-w start
 }
 

--- a/10/docker-entrypoint.sh
+++ b/10/docker-entrypoint.sh
@@ -212,11 +212,14 @@ docker_temp_server_start() {
 	if [ "$1" = 'postgres' ]; then
 		shift
 	fi
+
 	# internal start of server in order to allow setup using psql client
-	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	# does not listen on external TCP/IP and waits until start finishes
+	set -- "$@" -c listen_addresses='' -p 5432
+
 	PGUSER="${PGUSER:-$POSTGRES_USER}" \
 	pg_ctl -D "$PGDATA" \
-		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-o "$(printf '%q ' "$@")" \
 		-w start
 }
 

--- a/11/alpine/docker-entrypoint.sh
+++ b/11/alpine/docker-entrypoint.sh
@@ -212,11 +212,14 @@ docker_temp_server_start() {
 	if [ "$1" = 'postgres' ]; then
 		shift
 	fi
+
 	# internal start of server in order to allow setup using psql client
-	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	# does not listen on external TCP/IP and waits until start finishes
+	set -- "$@" -c listen_addresses='' -p 5432
+
 	PGUSER="${PGUSER:-$POSTGRES_USER}" \
 	pg_ctl -D "$PGDATA" \
-		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-o "$(printf '%q ' "$@")" \
 		-w start
 }
 

--- a/11/docker-entrypoint.sh
+++ b/11/docker-entrypoint.sh
@@ -212,11 +212,14 @@ docker_temp_server_start() {
 	if [ "$1" = 'postgres' ]; then
 		shift
 	fi
+
 	# internal start of server in order to allow setup using psql client
-	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	# does not listen on external TCP/IP and waits until start finishes
+	set -- "$@" -c listen_addresses='' -p 5432
+
 	PGUSER="${PGUSER:-$POSTGRES_USER}" \
 	pg_ctl -D "$PGDATA" \
-		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-o "$(printf '%q ' "$@")" \
 		-w start
 }
 

--- a/12/alpine/docker-entrypoint.sh
+++ b/12/alpine/docker-entrypoint.sh
@@ -212,11 +212,14 @@ docker_temp_server_start() {
 	if [ "$1" = 'postgres' ]; then
 		shift
 	fi
+
 	# internal start of server in order to allow setup using psql client
-	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	# does not listen on external TCP/IP and waits until start finishes
+	set -- "$@" -c listen_addresses='' -p 5432
+
 	PGUSER="${PGUSER:-$POSTGRES_USER}" \
 	pg_ctl -D "$PGDATA" \
-		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-o "$(printf '%q ' "$@")" \
 		-w start
 }
 

--- a/12/docker-entrypoint.sh
+++ b/12/docker-entrypoint.sh
@@ -212,11 +212,14 @@ docker_temp_server_start() {
 	if [ "$1" = 'postgres' ]; then
 		shift
 	fi
+
 	# internal start of server in order to allow setup using psql client
-	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	# does not listen on external TCP/IP and waits until start finishes
+	set -- "$@" -c listen_addresses='' -p 5432
+
 	PGUSER="${PGUSER:-$POSTGRES_USER}" \
 	pg_ctl -D "$PGDATA" \
-		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-o "$(printf '%q ' "$@")" \
 		-w start
 }
 

--- a/9.4/alpine/docker-entrypoint.sh
+++ b/9.4/alpine/docker-entrypoint.sh
@@ -212,11 +212,14 @@ docker_temp_server_start() {
 	if [ "$1" = 'postgres' ]; then
 		shift
 	fi
+
 	# internal start of server in order to allow setup using psql client
-	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	# does not listen on external TCP/IP and waits until start finishes
+	set -- "$@" -c listen_addresses='' -p 5432
+
 	PGUSER="${PGUSER:-$POSTGRES_USER}" \
 	pg_ctl -D "$PGDATA" \
-		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-o "$(printf '%q ' "$@")" \
 		-w start
 }
 

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -212,11 +212,14 @@ docker_temp_server_start() {
 	if [ "$1" = 'postgres' ]; then
 		shift
 	fi
+
 	# internal start of server in order to allow setup using psql client
-	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	# does not listen on external TCP/IP and waits until start finishes
+	set -- "$@" -c listen_addresses='' -p 5432
+
 	PGUSER="${PGUSER:-$POSTGRES_USER}" \
 	pg_ctl -D "$PGDATA" \
-		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-o "$(printf '%q ' "$@")" \
 		-w start
 }
 

--- a/9.5/alpine/docker-entrypoint.sh
+++ b/9.5/alpine/docker-entrypoint.sh
@@ -212,11 +212,14 @@ docker_temp_server_start() {
 	if [ "$1" = 'postgres' ]; then
 		shift
 	fi
+
 	# internal start of server in order to allow setup using psql client
-	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	# does not listen on external TCP/IP and waits until start finishes
+	set -- "$@" -c listen_addresses='' -p 5432
+
 	PGUSER="${PGUSER:-$POSTGRES_USER}" \
 	pg_ctl -D "$PGDATA" \
-		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-o "$(printf '%q ' "$@")" \
 		-w start
 }
 

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -212,11 +212,14 @@ docker_temp_server_start() {
 	if [ "$1" = 'postgres' ]; then
 		shift
 	fi
+
 	# internal start of server in order to allow setup using psql client
-	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	# does not listen on external TCP/IP and waits until start finishes
+	set -- "$@" -c listen_addresses='' -p 5432
+
 	PGUSER="${PGUSER:-$POSTGRES_USER}" \
 	pg_ctl -D "$PGDATA" \
-		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-o "$(printf '%q ' "$@")" \
 		-w start
 }
 

--- a/9.6/alpine/docker-entrypoint.sh
+++ b/9.6/alpine/docker-entrypoint.sh
@@ -212,11 +212,14 @@ docker_temp_server_start() {
 	if [ "$1" = 'postgres' ]; then
 		shift
 	fi
+
 	# internal start of server in order to allow setup using psql client
-	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	# does not listen on external TCP/IP and waits until start finishes
+	set -- "$@" -c listen_addresses='' -p 5432
+
 	PGUSER="${PGUSER:-$POSTGRES_USER}" \
 	pg_ctl -D "$PGDATA" \
-		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-o "$(printf '%q ' "$@")" \
 		-w start
 }
 

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -212,11 +212,14 @@ docker_temp_server_start() {
 	if [ "$1" = 'postgres' ]; then
 		shift
 	fi
+
 	# internal start of server in order to allow setup using psql client
-	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	# does not listen on external TCP/IP and waits until start finishes
+	set -- "$@" -c listen_addresses='' -p 5432
+
 	PGUSER="${PGUSER:-$POSTGRES_USER}" \
 	pg_ctl -D "$PGDATA" \
-		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-o "$(printf '%q ' "$@")" \
 		-w start
 }
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -212,11 +212,14 @@ docker_temp_server_start() {
 	if [ "$1" = 'postgres' ]; then
 		shift
 	fi
+
 	# internal start of server in order to allow setup using psql client
-	# does not listen on external TCP/IP and waits until start finishes (can be overridden via args)
+	# does not listen on external TCP/IP and waits until start finishes
+	set -- "$@" -c listen_addresses='' -p 5432
+
 	PGUSER="${PGUSER:-$POSTGRES_USER}" \
 	pg_ctl -D "$PGDATA" \
-		-o "-c listen_addresses='' $([ "$#" -gt 0 ] && printf '%q ' "$@")" \
+		-o "$(printf '%q ' "$@")" \
 		-w start
 }
 


### PR DESCRIPTION
Fixes #637