### PR TITLE
Add environment values for replication support

### DIFF
--- a/10/alpine/docker-entrypoint.sh
+++ b/10/alpine/docker-entrypoint.sh
@@ -87,6 +87,31 @@ docker_init_database_dir() {
 	fi
 }
 
+# initialize empty PGDATA directory with new database via 'pg_basebackup'
+# arguments to `pg_basebackup` can be passed via PRIMARY_SLOTNAME, PRIMARY_USER, PRIMARY_PASSWORD, PRIMARY_HOST and PRIMARY_PORT
+docker_create_database_basebackup() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
+
+	if [ "$POSTGRES_BASEBACKUP_WALDIR" ]; then
+		set -- --waldir "$POSTGRES_BASEBACKUP_WALDIR" "$@"
+	fi
+
+	eval 'pg_basebackup -D "$PGDATA" -Fp -X stream -S "$PRIMARY_SLOTNAME" -d postgresql://"$PRIMARY_USER":"$PRIMARY_PASSWORD"@"$PRIMARY_HOST":"$PRIMARY_PORT" -R -P '"$@"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
+
 # print large warning if POSTGRES_PASSWORD is empty
 docker_verify_minimum_env() {
 	# check password first so we can output the warning before postgres
@@ -185,6 +210,11 @@ docker_setup_env() {
 	file_env 'POSTGRES_USER' 'postgres'
 	file_env 'POSTGRES_DB' "$POSTGRES_USER"
 	file_env 'POSTGRES_INITDB_ARGS'
+	file_env 'PRIMARY_HOST'
+	file_env 'PRIMARY_PORT' '5432'
+	file_env 'PRIMARY_SLOTNAME' 'dockerslot'
+	file_env 'PRIMARY_USER' 'postgres'
+	file_env 'PRIMARY_PASSWORD'
 
 	declare -g DATABASE_ALREADY_EXISTS
 	# look specifically for PG_VERSION, as it is expected in the DB dir
@@ -203,6 +233,7 @@ pg_setup_hba_conf() {
 	{
 		echo
 		echo "host all all all $authMethod"
+		echo "host replication all all $authMethod"
 	} >> "$PGDATA/pg_hba.conf"
 }
 
@@ -247,7 +278,11 @@ _main() {
 		# only run initialization on an empty data directory
 		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
 			docker_verify_minimum_env
-			docker_init_database_dir
+			if [ "$PRIMARY_HOST" ]; then
+				docker_create_database_basebackup
+			else
+				docker_init_database_dir
+			fi
 			pg_setup_hba_conf
 
 			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless

--- a/10/docker-entrypoint.sh
+++ b/10/docker-entrypoint.sh
@@ -87,6 +87,31 @@ docker_init_database_dir() {
 	fi
 }
 
+# initialize empty PGDATA directory with new database via 'pg_basebackup'
+# arguments to `pg_basebackup` can be passed via PRIMARY_SLOTNAME, PRIMARY_USER, PRIMARY_PASSWORD, PRIMARY_HOST and PRIMARY_PORT
+docker_create_database_basebackup() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
+
+	if [ "$POSTGRES_BASEBACKUP_WALDIR" ]; then
+		set -- --waldir "$POSTGRES_BASEBACKUP_WALDIR" "$@"
+	fi
+
+	eval 'pg_basebackup -D "$PGDATA" -Fp -X stream -S "$PRIMARY_SLOTNAME" -d postgresql://"$PRIMARY_USER":"$PRIMARY_PASSWORD"@"$PRIMARY_HOST":"$PRIMARY_PORT" -R -P '"$@"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
+
 # print large warning if POSTGRES_PASSWORD is empty
 docker_verify_minimum_env() {
 	# check password first so we can output the warning before postgres
@@ -185,6 +210,11 @@ docker_setup_env() {
 	file_env 'POSTGRES_USER' 'postgres'
 	file_env 'POSTGRES_DB' "$POSTGRES_USER"
 	file_env 'POSTGRES_INITDB_ARGS'
+	file_env 'PRIMARY_HOST'
+	file_env 'PRIMARY_PORT' '5432'
+	file_env 'PRIMARY_SLOTNAME' 'dockerslot'
+	file_env 'PRIMARY_USER' 'postgres'
+	file_env 'PRIMARY_PASSWORD'
 
 	declare -g DATABASE_ALREADY_EXISTS
 	# look specifically for PG_VERSION, as it is expected in the DB dir
@@ -203,6 +233,7 @@ pg_setup_hba_conf() {
 	{
 		echo
 		echo "host all all all $authMethod"
+		echo "host replication all all $authMethod"
 	} >> "$PGDATA/pg_hba.conf"
 }
 
@@ -247,7 +278,11 @@ _main() {
 		# only run initialization on an empty data directory
 		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
 			docker_verify_minimum_env
-			docker_init_database_dir
+			if [ "$PRIMARY_HOST" ]; then
+				docker_create_database_basebackup
+			else
+				docker_init_database_dir
+			fi
 			pg_setup_hba_conf
 
 			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless

--- a/11/docker-entrypoint.sh
+++ b/11/docker-entrypoint.sh
@@ -87,6 +87,31 @@ docker_init_database_dir() {
 	fi
 }
 
+# initialize empty PGDATA directory with new database via 'pg_basebackup'
+# arguments to `pg_basebackup` can be passed via PRIMARY_SLOTNAME, PRIMARY_USER, PRIMARY_PASSWORD, PRIMARY_HOST and PRIMARY_PORT
+docker_create_database_basebackup() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
+
+	if [ "$POSTGRES_BASEBACKUP_WALDIR" ]; then
+		set -- --waldir "$POSTGRES_BASEBACKUP_WALDIR" "$@"
+	fi
+
+	eval 'pg_basebackup -D "$PGDATA" -Fp -X stream -C -S "$PRIMARY_SLOTNAME" -d postgresql://"$PRIMARY_USER":"$PRIMARY_PASSWORD"@"$PRIMARY_HOST":"$PRIMARY_PORT" -R -P '"$@"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
+
 # print large warning if POSTGRES_PASSWORD is empty
 docker_verify_minimum_env() {
 	# check password first so we can output the warning before postgres
@@ -185,6 +210,11 @@ docker_setup_env() {
 	file_env 'POSTGRES_USER' 'postgres'
 	file_env 'POSTGRES_DB' "$POSTGRES_USER"
 	file_env 'POSTGRES_INITDB_ARGS'
+	file_env 'PRIMARY_HOST'
+	file_env 'PRIMARY_PORT' '5432'
+	file_env 'PRIMARY_SLOTNAME' 'dockerslot'
+	file_env 'PRIMARY_USER' 'postgres'
+	file_env 'PRIMARY_PASSWORD'
 
 	declare -g DATABASE_ALREADY_EXISTS
 	# look specifically for PG_VERSION, as it is expected in the DB dir
@@ -203,6 +233,7 @@ pg_setup_hba_conf() {
 	{
 		echo
 		echo "host all all all $authMethod"
+		echo "host replication all all $authMethod"
 	} >> "$PGDATA/pg_hba.conf"
 }
 
@@ -247,7 +278,11 @@ _main() {
 		# only run initialization on an empty data directory
 		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
 			docker_verify_minimum_env
-			docker_init_database_dir
+			if [ "$PRIMARY_HOST" ]; then
+				docker_create_database_basebackup
+			else
+				docker_init_database_dir
+			fi
 			pg_setup_hba_conf
 
 			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless

--- a/12/docker-entrypoint.sh
+++ b/12/docker-entrypoint.sh
@@ -87,6 +87,31 @@ docker_init_database_dir() {
 	fi
 }
 
+# initialize empty PGDATA directory with new database via 'pg_basebackup'
+# arguments to `pg_basebackup` can be passed via PRIMARY_SLOTNAME, PRIMARY_USER, PRIMARY_PASSWORD, PRIMARY_HOST and PRIMARY_PORT
+docker_create_database_basebackup() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
+
+	if [ "$POSTGRES_BASEBACKUP_WALDIR" ]; then
+		set -- --waldir "$POSTGRES_BASEBACKUP_WALDIR" "$@"
+	fi
+
+	eval 'pg_basebackup -D "$PGDATA" -Fp -X stream -C -S "$PRIMARY_SLOTNAME" -d postgresql://"$PRIMARY_USER":"$PRIMARY_PASSWORD"@"$PRIMARY_HOST":"$PRIMARY_PORT" -R -P '"$@"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
+
 # print large warning if POSTGRES_PASSWORD is empty
 docker_verify_minimum_env() {
 	# check password first so we can output the warning before postgres
@@ -185,6 +210,11 @@ docker_setup_env() {
 	file_env 'POSTGRES_USER' 'postgres'
 	file_env 'POSTGRES_DB' "$POSTGRES_USER"
 	file_env 'POSTGRES_INITDB_ARGS'
+	file_env 'PRIMARY_HOST'
+	file_env 'PRIMARY_PORT' '5432'
+	file_env 'PRIMARY_SLOTNAME' 'dockerslot'
+	file_env 'PRIMARY_USER' 'postgres'
+	file_env 'PRIMARY_PASSWORD'
 
 	declare -g DATABASE_ALREADY_EXISTS
 	# look specifically for PG_VERSION, as it is expected in the DB dir
@@ -203,6 +233,7 @@ pg_setup_hba_conf() {
 	{
 		echo
 		echo "host all all all $authMethod"
+		echo "host replication all all $authMethod"
 	} >> "$PGDATA/pg_hba.conf"
 }
 
@@ -247,7 +278,11 @@ _main() {
 		# only run initialization on an empty data directory
 		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
 			docker_verify_minimum_env
-			docker_init_database_dir
+			if [ "$PRIMARY_HOST" ]; then
+				docker_create_database_basebackup
+			else
+				docker_init_database_dir
+			fi
 			pg_setup_hba_conf
 
 			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless

--- a/9.6/alpine/docker-entrypoint.sh
+++ b/9.6/alpine/docker-entrypoint.sh
@@ -87,6 +87,31 @@ docker_init_database_dir() {
 	fi
 }
 
+# initialize empty PGDATA directory with new database via 'pg_basebackup'
+# arguments to `pg_basebackup` can be passed via PRIMARY_SLOTNAME, PRIMARY_USER, PRIMARY_PASSWORD, PRIMARY_HOST and PRIMARY_PORT
+docker_create_database_basebackup() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
+
+	if [ "$POSTGRES_BASEBACKUP_WALDIR" ]; then
+		set -- --waldir "$POSTGRES_BASEBACKUP_WALDIR" "$@"
+	fi
+
+	eval 'pg_basebackup -D "$PGDATA" -Fp -X stream -S "$PRIMARY_SLOTNAME" -d postgresql://"$PRIMARY_USER":"$PRIMARY_PASSWORD"@"$PRIMARY_HOST":"$PRIMARY_PORT" -R -P '"$@"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
+
 # print large warning if POSTGRES_PASSWORD is empty
 docker_verify_minimum_env() {
 	# check password first so we can output the warning before postgres
@@ -185,6 +210,11 @@ docker_setup_env() {
 	file_env 'POSTGRES_USER' 'postgres'
 	file_env 'POSTGRES_DB' "$POSTGRES_USER"
 	file_env 'POSTGRES_INITDB_ARGS'
+	file_env 'PRIMARY_HOST'
+	file_env 'PRIMARY_PORT' '5432'
+	file_env 'PRIMARY_SLOTNAME' 'dockerslot'
+	file_env 'PRIMARY_USER' 'postgres'
+	file_env 'PRIMARY_PASSWORD'
 
 	declare -g DATABASE_ALREADY_EXISTS
 	# look specifically for PG_VERSION, as it is expected in the DB dir
@@ -203,6 +233,7 @@ pg_setup_hba_conf() {
 	{
 		echo
 		echo "host all all all $authMethod"
+		echo "host replication all all $authMethod"
 	} >> "$PGDATA/pg_hba.conf"
 }
 
@@ -247,7 +278,11 @@ _main() {
 		# only run initialization on an empty data directory
 		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
 			docker_verify_minimum_env
-			docker_init_database_dir
+			if [ "$PRIMARY_HOST" ]; then
+				docker_create_database_basebackup
+			else
+				docker_init_database_dir
+			fi
 			pg_setup_hba_conf
 
 			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -87,6 +87,31 @@ docker_init_database_dir() {
 	fi
 }
 
+# initialize empty PGDATA directory with new database via 'pg_basebackup'
+# arguments to `pg_basebackup` can be passed via PRIMARY_SLOTNAME, PRIMARY_USER, PRIMARY_PASSWORD, PRIMARY_HOST and PRIMARY_PORT
+docker_create_database_basebackup() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
+
+	if [ "$POSTGRES_BASEBACKUP_WALDIR" ]; then
+		set -- --waldir "$POSTGRES_BASEBACKUP_WALDIR" "$@"
+	fi
+
+	eval 'pg_basebackup -D "$PGDATA" -Fp -X stream -S "$PRIMARY_SLOTNAME" -d postgresql://"$PRIMARY_USER":"$PRIMARY_PASSWORD"@"$PRIMARY_HOST":"$PRIMARY_PORT" -R -P '"$@"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
+
 # print large warning if POSTGRES_PASSWORD is empty
 docker_verify_minimum_env() {
 	# check password first so we can output the warning before postgres
@@ -185,6 +210,11 @@ docker_setup_env() {
 	file_env 'POSTGRES_USER' 'postgres'
 	file_env 'POSTGRES_DB' "$POSTGRES_USER"
 	file_env 'POSTGRES_INITDB_ARGS'
+	file_env 'PRIMARY_HOST'
+	file_env 'PRIMARY_PORT' '5432'
+	file_env 'PRIMARY_SLOTNAME' 'dockerslot'
+	file_env 'PRIMARY_USER' 'postgres'
+	file_env 'PRIMARY_PASSWORD'
 
 	declare -g DATABASE_ALREADY_EXISTS
 	# look specifically for PG_VERSION, as it is expected in the DB dir
@@ -203,6 +233,7 @@ pg_setup_hba_conf() {
 	{
 		echo
 		echo "host all all all $authMethod"
+		echo "host replication all all $authMethod"
 	} >> "$PGDATA/pg_hba.conf"
 }
 
@@ -247,7 +278,11 @@ _main() {
 		# only run initialization on an empty data directory
 		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
 			docker_verify_minimum_env
-			docker_init_database_dir
+			if [ "$PRIMARY_HOST" ]; then
+				docker_create_database_basebackup
+			else
+				docker_init_database_dir
+			fi
 			pg_setup_hba_conf
 
 			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -87,6 +87,31 @@ docker_init_database_dir() {
 	fi
 }
 
+# initialize empty PGDATA directory with new database via 'pg_basebackup'
+# arguments to `pg_basebackup` can be passed via PRIMARY_SLOTNAME, PRIMARY_USER, PRIMARY_PASSWORD, PRIMARY_HOST and PRIMARY_PORT
+docker_create_database_basebackup() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	if ! getent passwd "$(id -u)" &> /dev/null && [ -e /usr/lib/libnss_wrapper.so ]; then
+		export LD_PRELOAD='/usr/lib/libnss_wrapper.so'
+		export NSS_WRAPPER_PASSWD="$(mktemp)"
+		export NSS_WRAPPER_GROUP="$(mktemp)"
+		echo "postgres:x:$(id -u):$(id -g):PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
+	fi
+
+	if [ "$POSTGRES_BASEBACKUP_WALDIR" ]; then
+		set -- --waldir "$POSTGRES_BASEBACKUP_WALDIR" "$@"
+	fi
+
+	eval 'pg_basebackup -D "$PGDATA" -Fp -X stream -C -S "$PRIMARY_SLOTNAME" -d postgresql://"$PRIMARY_USER":"$PRIMARY_PASSWORD"@"$PRIMARY_HOST":"$PRIMARY_PORT" -R -P '"$@"
+	# unset/cleanup "nss_wrapper" bits
+	if [ "${LD_PRELOAD:-}" = '/usr/lib/libnss_wrapper.so' ]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
+
 # print large warning if POSTGRES_PASSWORD is empty
 docker_verify_minimum_env() {
 	# check password first so we can output the warning before postgres
@@ -185,6 +210,11 @@ docker_setup_env() {
 	file_env 'POSTGRES_USER' 'postgres'
 	file_env 'POSTGRES_DB' "$POSTGRES_USER"
 	file_env 'POSTGRES_INITDB_ARGS'
+	file_env 'PRIMARY_HOST'
+	file_env 'PRIMARY_PORT' '5432'
+	file_env 'PRIMARY_SLOTNAME' 'dockerslot'
+	file_env 'PRIMARY_USER' 'postgres'
+	file_env 'PRIMARY_PASSWORD'
 
 	declare -g DATABASE_ALREADY_EXISTS
 	# look specifically for PG_VERSION, as it is expected in the DB dir
@@ -203,6 +233,7 @@ pg_setup_hba_conf() {
 	{
 		echo
 		echo "host all all all $authMethod"
+		echo "host replication all all $authMethod"
 	} >> "$PGDATA/pg_hba.conf"
 }
 
@@ -247,7 +278,11 @@ _main() {
 		# only run initialization on an empty data directory
 		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
 			docker_verify_minimum_env
-			docker_init_database_dir
+			if [ "$PRIMARY_HOST" ]; then
+				docker_create_database_basebackup
+			else
+				docker_init_database_dir
+			fi
 			pg_setup_hba_conf
 
 			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless


### PR DESCRIPTION
This patch includes physical replication support.
If you want to create a standby node, set the PRIMARY_HOST and PRIMARY_PASSWORD environment variables.

```
version: '3.5'

services:
  primarynode:
    image: postgres
    environment:
      POSTGRES_PASSWORD: 12345

  standbynode:
    image: postgres
    depends_on:
      - primarynode
    restart: always
    environment:
      PRIMARY_HOST: primarynode
      PRIMARY_PASSWORD: 12345
```