### PR TITLE
Error when `POSTGRES_PASSWORD` is unset like mysql

### DIFF
--- a/10/alpine/docker-entrypoint.sh
+++ b/10/alpine/docker-entrypoint.sh
@@ -44,7 +44,7 @@ docker_create_db_directories() {
 	chmod 775 /var/run/postgresql || :
 
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
-	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
 		if [ "$user" = '0' ]; then
 			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
@@ -74,7 +74,7 @@ docker_init_database_dir() {
 		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
 	fi
 
-	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
 		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
 	fi
 

--- a/10/docker-entrypoint.sh
+++ b/10/docker-entrypoint.sh
@@ -44,7 +44,7 @@ docker_create_db_directories() {
 	chmod 775 /var/run/postgresql || :
 
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
-	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
 		if [ "$user" = '0' ]; then
 			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
@@ -74,7 +74,7 @@ docker_init_database_dir() {
 		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
 	fi
 
-	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
 		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
 	fi
 

--- a/11/alpine/docker-entrypoint.sh
+++ b/11/alpine/docker-entrypoint.sh
@@ -44,7 +44,7 @@ docker_create_db_directories() {
 	chmod 775 /var/run/postgresql || :
 
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
-	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
 		if [ "$user" = '0' ]; then
 			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
@@ -74,7 +74,7 @@ docker_init_database_dir() {
 		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
 	fi
 
-	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
 		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
 	fi
 

--- a/11/docker-entrypoint.sh
+++ b/11/docker-entrypoint.sh
@@ -44,7 +44,7 @@ docker_create_db_directories() {
 	chmod 775 /var/run/postgresql || :
 
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
-	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
 		if [ "$user" = '0' ]; then
 			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
@@ -74,7 +74,7 @@ docker_init_database_dir() {
 		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
 	fi
 
-	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
 		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
 	fi
 

--- a/12/alpine/docker-entrypoint.sh
+++ b/12/alpine/docker-entrypoint.sh
@@ -44,7 +44,7 @@ docker_create_db_directories() {
 	chmod 775 /var/run/postgresql || :
 
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
-	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
 		if [ "$user" = '0' ]; then
 			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
@@ -74,7 +74,7 @@ docker_init_database_dir() {
 		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
 	fi
 
-	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
 		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
 	fi
 

--- a/12/docker-entrypoint.sh
+++ b/12/docker-entrypoint.sh
@@ -44,7 +44,7 @@ docker_create_db_directories() {
 	chmod 775 /var/run/postgresql || :
 
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
-	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
 		if [ "$user" = '0' ]; then
 			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
@@ -74,7 +74,7 @@ docker_init_database_dir() {
 		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
 	fi
 
-	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
 		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
 	fi
 

--- a/9.4/alpine/docker-entrypoint.sh
+++ b/9.4/alpine/docker-entrypoint.sh
@@ -44,7 +44,7 @@ docker_create_db_directories() {
 	chmod 775 /var/run/postgresql || :
 
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
-	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_XLOGDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_XLOGDIR"
 		if [ "$user" = '0' ]; then
 			find "$POSTGRES_INITDB_XLOGDIR" \! -user postgres -exec chown postgres '{}' +
@@ -74,7 +74,7 @@ docker_init_database_dir() {
 		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
 	fi
 
-	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_XLOGDIR" ]; then
 		set -- --xlogdir "$POSTGRES_INITDB_XLOGDIR" "$@"
 	fi
 

--- a/9.4/docker-entrypoint.sh
+++ b/9.4/docker-entrypoint.sh
@@ -44,7 +44,7 @@ docker_create_db_directories() {
 	chmod 775 /var/run/postgresql || :
 
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
-	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_XLOGDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_XLOGDIR"
 		if [ "$user" = '0' ]; then
 			find "$POSTGRES_INITDB_XLOGDIR" \! -user postgres -exec chown postgres '{}' +
@@ -74,7 +74,7 @@ docker_init_database_dir() {
 		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
 	fi
 
-	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_XLOGDIR" ]; then
 		set -- --xlogdir "$POSTGRES_INITDB_XLOGDIR" "$@"
 	fi
 

--- a/9.5/alpine/docker-entrypoint.sh
+++ b/9.5/alpine/docker-entrypoint.sh
@@ -44,7 +44,7 @@ docker_create_db_directories() {
 	chmod 775 /var/run/postgresql || :
 
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
-	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_XLOGDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_XLOGDIR"
 		if [ "$user" = '0' ]; then
 			find "$POSTGRES_INITDB_XLOGDIR" \! -user postgres -exec chown postgres '{}' +
@@ -74,7 +74,7 @@ docker_init_database_dir() {
 		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
 	fi
 
-	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_XLOGDIR" ]; then
 		set -- --xlogdir "$POSTGRES_INITDB_XLOGDIR" "$@"
 	fi
 

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -44,7 +44,7 @@ docker_create_db_directories() {
 	chmod 775 /var/run/postgresql || :
 
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
-	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_XLOGDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_XLOGDIR"
 		if [ "$user" = '0' ]; then
 			find "$POSTGRES_INITDB_XLOGDIR" \! -user postgres -exec chown postgres '{}' +
@@ -74,7 +74,7 @@ docker_init_database_dir() {
 		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
 	fi
 
-	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_XLOGDIR" ]; then
 		set -- --xlogdir "$POSTGRES_INITDB_XLOGDIR" "$@"
 	fi
 

--- a/9.6/alpine/docker-entrypoint.sh
+++ b/9.6/alpine/docker-entrypoint.sh
@@ -44,7 +44,7 @@ docker_create_db_directories() {
 	chmod 775 /var/run/postgresql || :
 
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
-	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_XLOGDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_XLOGDIR"
 		if [ "$user" = '0' ]; then
 			find "$POSTGRES_INITDB_XLOGDIR" \! -user postgres -exec chown postgres '{}' +
@@ -74,7 +74,7 @@ docker_init_database_dir() {
 		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
 	fi
 
-	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_XLOGDIR" ]; then
 		set -- --xlogdir "$POSTGRES_INITDB_XLOGDIR" "$@"
 	fi
 

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -44,7 +44,7 @@ docker_create_db_directories() {
 	chmod 775 /var/run/postgresql || :
 
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
-	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_XLOGDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_XLOGDIR"
 		if [ "$user" = '0' ]; then
 			find "$POSTGRES_INITDB_XLOGDIR" \! -user postgres -exec chown postgres '{}' +
@@ -74,7 +74,7 @@ docker_init_database_dir() {
 		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
 	fi
 
-	if [ "$POSTGRES_INITDB_XLOGDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_XLOGDIR" ]; then
 		set -- --xlogdir "$POSTGRES_INITDB_XLOGDIR" "$@"
 	fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -44,7 +44,7 @@ docker_create_db_directories() {
 	chmod 775 /var/run/postgresql || :
 
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
-	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
 		if [ "$user" = '0' ]; then
 			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
@@ -74,7 +74,7 @@ docker_init_database_dir() {
 		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
 	fi
 
-	if [ "$POSTGRES_INITDB_WALDIR" ]; then
+	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
 		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
 	fi
 


### PR DESCRIPTION
Add `POSTGRES_HOST_AUTH_METHOD` to bring back old behavior and be similar to `MYSQL_ALLOW_EMPTY_PASSWORD`, but add warning when "trust" is used since it disables all passwords


Fixes #580.