### PR TITLE
Set the postgres user shell to sh

### DIFF
--- a/12/alpine/Dockerfile
+++ b/12/alpine/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.11
 # https://git.alpinelinux.org/aports/tree/main/postgresql/postgresql.pre-install?h=3.11-stable
 RUN set -eux; \
 	addgroup -g 70 -S postgres; \
-	adduser -u 70 -S -D -G postgres -H -h /var/lib/postgresql postgres; \
+	adduser -u 70 -S -D -G postgres -H -h /var/lib/postgresql -s /bin/sh postgres; \
 	mkdir -p /var/lib/postgresql; \
 	chown -R postgres:postgres /var/lib/postgresql
 


### PR DESCRIPTION
The adduser command creates the postgres user without specifying the default shell.
alpine-3.11 creates the user with /bin/nologin by default, which differs from the way the user was created in alpine-3.10.
Also, the creation of the postgres user in aports (https://git.alpinelinux.org/aports/tree/main/postgresql/postgresql.pre-install?h=3.11-stable) suggests the usage of /bin/sh.
Without a shell being specified we can't su to the postgres user.