### PR TITLE
Add .sql.xz support to docker-entrypoint-initdb.d

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -48,12 +48,16 @@ RUN set -eux; \
 	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 # install "nss_wrapper" in case we need to fake "/etc/passwd" and "/etc/group" (especially for OpenShift)
 # https://github.com/docker-library/postgres/issues/359
 # https://cwrap.org/nss_wrapper.html
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends libnss-wrapper; \
+		libnss-wrapper \
+# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+		xz-utils \
+	; \
 	rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /docker-entrypoint-initdb.d

--- a/10/alpine/docker-entrypoint.sh
+++ b/10/alpine/docker-entrypoint.sh
@@ -164,6 +164,7 @@ docker_process_init_files() {
 				;;
 			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
 			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz) echo "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
 			*)        echo "$0: ignoring $f" ;;
 		esac
 		echo

--- a/10/docker-entrypoint.sh
+++ b/10/docker-entrypoint.sh
@@ -164,6 +164,7 @@ docker_process_init_files() {
 				;;
 			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
 			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz) echo "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
 			*)        echo "$0: ignoring $f" ;;
 		esac
 		echo

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -48,12 +48,16 @@ RUN set -eux; \
 	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 # install "nss_wrapper" in case we need to fake "/etc/passwd" and "/etc/group" (especially for OpenShift)
 # https://github.com/docker-library/postgres/issues/359
 # https://cwrap.org/nss_wrapper.html
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends libnss-wrapper; \
+		libnss-wrapper \
+# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+		xz-utils \
+	; \
 	rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /docker-entrypoint-initdb.d

--- a/11/alpine/docker-entrypoint.sh
+++ b/11/alpine/docker-entrypoint.sh
@@ -164,6 +164,7 @@ docker_process_init_files() {
 				;;
 			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
 			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz) echo "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
 			*)        echo "$0: ignoring $f" ;;
 		esac
 		echo

--- a/11/docker-entrypoint.sh
+++ b/11/docker-entrypoint.sh
@@ -164,6 +164,7 @@ docker_process_init_files() {
 				;;
 			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
 			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz) echo "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
 			*)        echo "$0: ignoring $f" ;;
 		esac
 		echo

--- a/12/Dockerfile
+++ b/12/Dockerfile
@@ -48,12 +48,16 @@ RUN set -eux; \
 	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 # install "nss_wrapper" in case we need to fake "/etc/passwd" and "/etc/group" (especially for OpenShift)
 # https://github.com/docker-library/postgres/issues/359
 # https://cwrap.org/nss_wrapper.html
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends libnss-wrapper; \
+		libnss-wrapper \
+# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+		xz-utils \
+	; \
 	rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /docker-entrypoint-initdb.d

--- a/12/alpine/docker-entrypoint.sh
+++ b/12/alpine/docker-entrypoint.sh
@@ -164,6 +164,7 @@ docker_process_init_files() {
 				;;
 			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
 			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz) echo "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
 			*)        echo "$0: ignoring $f" ;;
 		esac
 		echo

--- a/12/docker-entrypoint.sh
+++ b/12/docker-entrypoint.sh
@@ -164,6 +164,7 @@ docker_process_init_files() {
 				;;
 			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
 			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz) echo "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
 			*)        echo "$0: ignoring $f" ;;
 		esac
 		echo

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -48,12 +48,16 @@ RUN set -eux; \
 	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 # install "nss_wrapper" in case we need to fake "/etc/passwd" and "/etc/group" (especially for OpenShift)
 # https://github.com/docker-library/postgres/issues/359
 # https://cwrap.org/nss_wrapper.html
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends libnss-wrapper; \
+		libnss-wrapper \
+# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+		xz-utils \
+	; \
 	rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /docker-entrypoint-initdb.d

--- a/9.5/alpine/docker-entrypoint.sh
+++ b/9.5/alpine/docker-entrypoint.sh
@@ -164,6 +164,7 @@ docker_process_init_files() {
 				;;
 			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
 			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz) echo "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
 			*)        echo "$0: ignoring $f" ;;
 		esac
 		echo

--- a/9.5/docker-entrypoint.sh
+++ b/9.5/docker-entrypoint.sh
@@ -164,6 +164,7 @@ docker_process_init_files() {
 				;;
 			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
 			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz) echo "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
 			*)        echo "$0: ignoring $f" ;;
 		esac
 		echo

--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -48,12 +48,16 @@ RUN set -eux; \
 	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 # install "nss_wrapper" in case we need to fake "/etc/passwd" and "/etc/group" (especially for OpenShift)
 # https://github.com/docker-library/postgres/issues/359
 # https://cwrap.org/nss_wrapper.html
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends libnss-wrapper; \
+		libnss-wrapper \
+# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+		xz-utils \
+	; \
 	rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /docker-entrypoint-initdb.d

--- a/9.6/alpine/docker-entrypoint.sh
+++ b/9.6/alpine/docker-entrypoint.sh
@@ -164,6 +164,7 @@ docker_process_init_files() {
 				;;
 			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
 			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz) echo "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
 			*)        echo "$0: ignoring $f" ;;
 		esac
 		echo

--- a/9.6/docker-entrypoint.sh
+++ b/9.6/docker-entrypoint.sh
@@ -164,6 +164,7 @@ docker_process_init_files() {
 				;;
 			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
 			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz) echo "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
 			*)        echo "$0: ignoring $f" ;;
 		esac
 		echo

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -48,12 +48,16 @@ RUN set -eux; \
 	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 # install "nss_wrapper" in case we need to fake "/etc/passwd" and "/etc/group" (especially for OpenShift)
 # https://github.com/docker-library/postgres/issues/359
 # https://cwrap.org/nss_wrapper.html
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends libnss-wrapper; \
+		libnss-wrapper \
+# install "xz-utils" for .sql.xz docker-entrypoint-initdb.d files
+		xz-utils \
+	; \
 	rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /docker-entrypoint-initdb.d

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -164,6 +164,7 @@ docker_process_init_files() {
 				;;
 			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
 			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz) echo "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
 			*)        echo "$0: ignoring $f" ;;
 		esac
 		echo


### PR DESCRIPTION
`xzcat` is provided by `busybox` in Alpine images.
```console
$ docker run -it --rm postgres:alpine bash
bash-5.0# which xzcat
/usr/bin/xzcat
bash-5.0# ls -al /usr/bin/xzcat
lrwxrwxrwx    1 root     root            12 Jan 16 21:52 /usr/bin/xzcat -> /bin/busybox
```

Mirroring addition done in MariaDB: https://github.com/docker-library/mariadb/pull/288 and MySQL: https://github.com/docker-library/mysql/pull/637.