### PR TITLE
Keep postgres static libraries in Alpine images

### DIFF
--- a/10/alpine/Dockerfile
+++ b/10/alpine/Dockerfile
@@ -130,7 +130,6 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	find /usr/local -name '*.a' -delete; \
 	\
 	postgres --version
 

--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -132,7 +132,6 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	find /usr/local -name '*.a' -delete; \
 	\
 	postgres --version
 

--- a/12/alpine/Dockerfile
+++ b/12/alpine/Dockerfile
@@ -132,7 +132,6 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	find /usr/local -name '*.a' -delete; \
 	\
 	postgres --version
 

--- a/13/alpine/Dockerfile
+++ b/13/alpine/Dockerfile
@@ -132,7 +132,6 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	find /usr/local -name '*.a' -delete; \
 	\
 	postgres --version
 

--- a/9.5/alpine/Dockerfile
+++ b/9.5/alpine/Dockerfile
@@ -128,7 +128,6 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	find /usr/local -name '*.a' -delete; \
 	\
 	postgres --version
 

--- a/9.6/alpine/Dockerfile
+++ b/9.6/alpine/Dockerfile
@@ -128,7 +128,6 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	find /usr/local -name '*.a' -delete; \
 	\
 	postgres --version
 

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -132,7 +132,6 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	find /usr/local -name '*.a' -delete; \
 	\
 	postgres --version
 


### PR DESCRIPTION
Do not remove static postgres libraries from Alpine based images.
This add near 1.4MB to image size, but allow to complie some extentions
like repmgr without errors