### PR TITLE
Set GID and UID via ENV variables

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -11,11 +11,13 @@ RUN set -ex; \
 		rm -rf /var/lib/apt/lists/*; \
 	fi
 
+ENV GID 999
+ENV UID 999
 # explicitly set user/group IDs
 RUN set -eux; \
-	groupadd -r postgres --gid=999; \
+	groupadd -r postgres --gid=$GID; \
 # https://salsa.debian.org/postgresql/postgresql-common/blob/997d842ee744687d99a2b2d95c1083a2615c79e8/debian/postgresql-common.postinst#L32-35
-	useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
+	useradd -r -g postgres --uid=$UID --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
 # also create the postgres user's home directory with appropriate permissions
 # see https://github.com/docker-library/postgres/issues/274
 	mkdir -p /var/lib/postgresql; \

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -11,11 +11,13 @@ RUN set -ex; \
 		rm -rf /var/lib/apt/lists/*; \
 	fi
 
+ENV GID 999
+ENV UID 999
 # explicitly set user/group IDs
 RUN set -eux; \
-	groupadd -r postgres --gid=999; \
+	groupadd -r postgres --gid=$GID; \
 # https://salsa.debian.org/postgresql/postgresql-common/blob/997d842ee744687d99a2b2d95c1083a2615c79e8/debian/postgresql-common.postinst#L32-35
-	useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
+	useradd -r -g postgres --uid=$UID --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
 # also create the postgres user's home directory with appropriate permissions
 # see https://github.com/docker-library/postgres/issues/274
 	mkdir -p /var/lib/postgresql; \

--- a/12/Dockerfile
+++ b/12/Dockerfile
@@ -11,11 +11,13 @@ RUN set -ex; \
 		rm -rf /var/lib/apt/lists/*; \
 	fi
 
+ENV GID 999
+ENV UID 999
 # explicitly set user/group IDs
 RUN set -eux; \
-	groupadd -r postgres --gid=999; \
+	groupadd -r postgres --gid=$GID; \
 # https://salsa.debian.org/postgresql/postgresql-common/blob/997d842ee744687d99a2b2d95c1083a2615c79e8/debian/postgresql-common.postinst#L32-35
-	useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
+	useradd -r -g postgres --uid=$UID --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
 # also create the postgres user's home directory with appropriate permissions
 # see https://github.com/docker-library/postgres/issues/274
 	mkdir -p /var/lib/postgresql; \

--- a/13/Dockerfile
+++ b/13/Dockerfile
@@ -11,11 +11,13 @@ RUN set -ex; \
 		rm -rf /var/lib/apt/lists/*; \
 	fi
 
+ENV GID 999
+ENV UID 999
 # explicitly set user/group IDs
 RUN set -eux; \
-	groupadd -r postgres --gid=999; \
+	groupadd -r postgres --gid=$GID; \
 # https://salsa.debian.org/postgresql/postgresql-common/blob/997d842ee744687d99a2b2d95c1083a2615c79e8/debian/postgresql-common.postinst#L32-35
-	useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
+	useradd -r -g postgres --uid=$UID --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
 # also create the postgres user's home directory with appropriate permissions
 # see https://github.com/docker-library/postgres/issues/274
 	mkdir -p /var/lib/postgresql; \

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -11,11 +11,13 @@ RUN set -ex; \
 		rm -rf /var/lib/apt/lists/*; \
 	fi
 
+ENV GID 999
+ENV UID 999
 # explicitly set user/group IDs
 RUN set -eux; \
-	groupadd -r postgres --gid=999; \
+	groupadd -r postgres --gid=$GID; \
 # https://salsa.debian.org/postgresql/postgresql-common/blob/997d842ee744687d99a2b2d95c1083a2615c79e8/debian/postgresql-common.postinst#L32-35
-	useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
+	useradd -r -g postgres --uid=$UID --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
 # also create the postgres user's home directory with appropriate permissions
 # see https://github.com/docker-library/postgres/issues/274
 	mkdir -p /var/lib/postgresql; \

--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -11,11 +11,13 @@ RUN set -ex; \
 		rm -rf /var/lib/apt/lists/*; \
 	fi
 
+ENV GID 999
+ENV UID 999
 # explicitly set user/group IDs
 RUN set -eux; \
-	groupadd -r postgres --gid=999; \
+	groupadd -r postgres --gid=$GID; \
 # https://salsa.debian.org/postgresql/postgresql-common/blob/997d842ee744687d99a2b2d95c1083a2615c79e8/debian/postgresql-common.postinst#L32-35
-	useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
+	useradd -r -g postgres --uid=$UID --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
 # also create the postgres user's home directory with appropriate permissions
 # see https://github.com/docker-library/postgres/issues/274
 	mkdir -p /var/lib/postgresql; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -10,12 +10,14 @@ RUN set -ex; \
 		; \
 		rm -rf /var/lib/apt/lists/*; \
 	fi
-
+	
+ENV GID 999
+ENV UID 999
 # explicitly set user/group IDs
 RUN set -eux; \
-	groupadd -r postgres --gid=999; \
+	groupadd -r postgres --gid=$GID; \
 # https://salsa.debian.org/postgresql/postgresql-common/blob/997d842ee744687d99a2b2d95c1083a2615c79e8/debian/postgresql-common.postinst#L32-35
-	useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
+	useradd -r -g postgres --uid=$UID --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
 # also create the postgres user's home directory with appropriate permissions
 # see https://github.com/docker-library/postgres/issues/274
 	mkdir -p /var/lib/postgresql; \


### PR DESCRIPTION
Add convenient way to set UID and GID of postgres user and group via ENV variables.

In some cases UID/GID 999 is already blocked by another user (for example openmediavault uses 999 as UID for the openmediavault user). This results in postgres docker container using the already existing user.

This Pull request also adresses issue #709