### PR TITLE
Do not try to create database 'template1'

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -188,7 +188,7 @@ docker_process_sql() {
 # create initial database
 # uses environment variables for input: POSTGRES_DB
 docker_setup_db() {
-	if [ "$POSTGRES_DB" != 'postgres' ]; then
+	if [ "$POSTGRES_DB" != 'postgres' ] || [ "$POSTGRES_DB" != 'template1' ]; then
 		POSTGRES_DB= docker_process_sql --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
 			CREATE DATABASE :"db" ;
 		EOSQL


### PR DESCRIPTION
When passing `POSTGRES_DB=template1`, `docker-entrypoint.sh` tries to create database `template1`. It fails since `template1` is always present by default.
`docker-entrypoint.sh` already skips `postgres` database creation. This changes makes `docker-entrypoint.sh` skip `template1` database creation.