### PR TITLE
Adjust tagging to enforce explicit pre-release opt-in

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -80,8 +80,14 @@ for version in "${versions[@]}"; do
 		versionAliases+=( $fullVersion )
 		fullVersion="${fullVersion%[.-]*}"
 	done
+	# skip unadorned "version" on prereleases: https://www.postgresql.org/developer/beta/
+	# - https://github.com/docker-library/postgres/issues/662
+	# - https://github.com/docker-library/postgres/issues/784
+	case "$pgdgVersion" in
+		*alpha* | *beta*| *rc*) ;;
+		*) versionAliases+=( $version ) ;;
+	esac
 	versionAliases+=(
-		$version
 		${aliases[$version]:-}
 	)
 


### PR DESCRIPTION
I rewound to commit 09c342c55544feaff8740086bb98c54ad936ac60 to test this and verify that `postgres:13` would go away (and only `postgres:13-rc1` would remain).

- https://github.com/docker-library/postgres/issues/662
- https://github.com/docker-library/postgres/issues/784