### PR TITLE
Add APT pinning for "postgresql" package

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -90,6 +90,18 @@ RUN set -ex; \
 # see note below about "*.pyc" files
 	export PYTHONDONTWRITEBYTECODE=1; \
 	\
+	{ \
+		echo 'Explanation: block installation of the "postgresql" metapackage, since it will almost always pull in something different than we expect'; \
+		echo 'Package: postgresql'; \
+		echo 'Pin: version *'; \
+		echo 'Pin-Priority: -10'; \
+		echo; \
+		echo 'Explanation: block installation of Debian postgresql packages, since we only want upstream'; \
+		echo 'Package: postgresql* libpq*'; \
+		echo 'Pin: release o=Debian'; \
+		echo 'Pin-Priority: -10'; \
+	} > /etc/apt/preferences.d/postgres.pref; \
+	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
 		amd64 | i386 | ppc64el) \

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -90,6 +90,18 @@ RUN set -ex; \
 # see note below about "*.pyc" files
 	export PYTHONDONTWRITEBYTECODE=1; \
 	\
+	{ \
+		echo 'Explanation: block installation of the "postgresql" metapackage, since it will almost always pull in something different than we expect'; \
+		echo 'Package: postgresql'; \
+		echo 'Pin: version *'; \
+		echo 'Pin-Priority: -10'; \
+		echo; \
+		echo 'Explanation: block installation of Debian postgresql packages, since we only want upstream'; \
+		echo 'Package: postgresql* libpq*'; \
+		echo 'Pin: release o=Debian'; \
+		echo 'Pin-Priority: -10'; \
+	} > /etc/apt/preferences.d/postgres.pref; \
+	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
 		amd64 | i386 | ppc64el) \

--- a/12/Dockerfile
+++ b/12/Dockerfile
@@ -90,6 +90,18 @@ RUN set -ex; \
 # see note below about "*.pyc" files
 	export PYTHONDONTWRITEBYTECODE=1; \
 	\
+	{ \
+		echo 'Explanation: block installation of the "postgresql" metapackage, since it will almost always pull in something different than we expect'; \
+		echo 'Package: postgresql'; \
+		echo 'Pin: version *'; \
+		echo 'Pin-Priority: -10'; \
+		echo; \
+		echo 'Explanation: block installation of Debian postgresql packages, since we only want upstream'; \
+		echo 'Package: postgresql* libpq*'; \
+		echo 'Pin: release o=Debian'; \
+		echo 'Pin-Priority: -10'; \
+	} > /etc/apt/preferences.d/postgres.pref; \
+	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
 		amd64 | arm64 | i386 | ppc64el) \

--- a/13/Dockerfile
+++ b/13/Dockerfile
@@ -90,6 +90,18 @@ RUN set -ex; \
 # see note below about "*.pyc" files
 	export PYTHONDONTWRITEBYTECODE=1; \
 	\
+	{ \
+		echo 'Explanation: block installation of the "postgresql" metapackage, since it will almost always pull in something different than we expect'; \
+		echo 'Package: postgresql'; \
+		echo 'Pin: version *'; \
+		echo 'Pin-Priority: -10'; \
+		echo; \
+		echo 'Explanation: block installation of Debian postgresql packages, since we only want upstream'; \
+		echo 'Package: postgresql* libpq*'; \
+		echo 'Pin: release o=Debian'; \
+		echo 'Pin-Priority: -10'; \
+	} > /etc/apt/preferences.d/postgres.pref; \
+	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
 		amd64 | arm64 | i386 | ppc64el) \

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -90,6 +90,18 @@ RUN set -ex; \
 # see note below about "*.pyc" files
 	export PYTHONDONTWRITEBYTECODE=1; \
 	\
+	{ \
+		echo 'Explanation: block installation of the "postgresql" metapackage, since it will almost always pull in something different than we expect'; \
+		echo 'Package: postgresql'; \
+		echo 'Pin: version *'; \
+		echo 'Pin-Priority: -10'; \
+		echo; \
+		echo 'Explanation: block installation of Debian postgresql packages, since we only want upstream'; \
+		echo 'Package: postgresql* libpq*'; \
+		echo 'Pin: release o=Debian'; \
+		echo 'Pin-Priority: -10'; \
+	} > /etc/apt/preferences.d/postgres.pref; \
+	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
 		amd64 | i386 | ppc64el) \

--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -90,6 +90,18 @@ RUN set -ex; \
 # see note below about "*.pyc" files
 	export PYTHONDONTWRITEBYTECODE=1; \
 	\
+	{ \
+		echo 'Explanation: block installation of the "postgresql" metapackage, since it will almost always pull in something different than we expect'; \
+		echo 'Package: postgresql'; \
+		echo 'Pin: version *'; \
+		echo 'Pin-Priority: -10'; \
+		echo; \
+		echo 'Explanation: block installation of Debian postgresql packages, since we only want upstream'; \
+		echo 'Package: postgresql* libpq*'; \
+		echo 'Pin: release o=Debian'; \
+		echo 'Pin-Priority: -10'; \
+	} > /etc/apt/preferences.d/postgres.pref; \
+	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
 		amd64 | i386 | ppc64el) \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -90,6 +90,18 @@ RUN set -ex; \
 # see note below about "*.pyc" files
 	export PYTHONDONTWRITEBYTECODE=1; \
 	\
+	{ \
+		echo 'Explanation: block installation of the "postgresql" metapackage, since it will almost always pull in something different than we expect'; \
+		echo 'Package: postgresql'; \
+		echo 'Pin: version *'; \
+		echo 'Pin-Priority: -10'; \
+		echo; \
+		echo 'Explanation: block installation of Debian postgresql packages, since we only want upstream'; \
+		echo 'Package: postgresql* libpq*'; \
+		echo 'Pin: release o=Debian'; \
+		echo 'Pin-Priority: -10'; \
+	} > /etc/apt/preferences.d/postgres.pref; \
+	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
 		%%ARCH_LIST%%) \


### PR DESCRIPTION
We had a confusing report that `postgres:12` contained PostgreSQL 13 -- we weren't able to reproduce, but the reporter mentioned "debugging what's wrong with my dockerfiles" (https://github.com/docker-library/postgres/issues/799) so the best we can figure is that they somehow ended up installing `postgresql` (either directly or indirectly via `Depends:`).

This adds APT pinning to ensure that can't succeed unless installing `postgresql` will give the same major version as the current image.

I'm honestly a little bit on the fence here -- there's a solid argument to be made for blocking this metapackage entirely instead (since installing it could bring a totally different install and/or version of PostgreSQL, in extreme cases).

I could also see an argument for creating our own mini virtual package and installing it instead, but IMO that's really a bridge too far.

I think it would probably also be useful for us to test blocking all the relevant Debian-provided packages, since they're low-hanging fruit that's not what we're after.