### PR TITLE
Implement TODO for -Eeuo

### DIFF
--- a/13/docker-entrypoint.sh
+++ b/13/docker-entrypoint.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-set -Eeo pipefail
-# TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
+set -Eeuo pipefail
 
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'


### PR DESCRIPTION
I noticed the TODO comment for switching to `-Eeuo` when reviewing the entrypoint for 13.2. I did the switch after searching for a PR that does this but couldnt find one.