### PR TITLE
minimal Pg 14beta1 - update

### DIFF
--- a/12/Dockerfile
+++ b/12/Dockerfile
@@ -181,7 +181,6 @@ RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PG
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/13/Dockerfile
+++ b/13/Dockerfile
@@ -183,7 +183,6 @@ RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PG
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/14/Dockerfile
+++ b/14/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 RUN set -ex; \
 	if ! command -v gpg > /dev/null; then \
@@ -82,8 +82,8 @@ RUN set -ex; \
 	rm -rf "$GNUPGHOME"; \
 	apt-key list
 
-ENV PG_MAJOR 9.5
-ENV PG_VERSION 9.5.25-1.pgdg90+1
+ENV PG_MAJOR 14
+ENV PG_VERSION 14~beta1-1.pgdg100+1
 
 RUN set -ex; \
 	\
@@ -92,22 +92,22 @@ RUN set -ex; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
-		amd64 | i386 | ppc64el) \
+		amd64 | arm64 | i386 | ppc64el) \
 # arches officialy built by upstream
-			echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main $PG_MAJOR" > /etc/apt/sources.list.d/pgdg.list; \
+			echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main $PG_MAJOR" > /etc/apt/sources.list.d/pgdg.list; \
 			apt-get update; \
 			;; \
 		*) \
 # we're on an architecture upstream doesn't officially build for
 # let's build binaries from their published source packages
-			echo "deb-src http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main $PG_MAJOR" > /etc/apt/sources.list.d/pgdg.list; \
+			echo "deb-src http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main $PG_MAJOR" > /etc/apt/sources.list.d/pgdg.list; \
 			\
 			case "$PG_MAJOR" in \
 				9.* | 10 ) ;; \
 				*) \
 # https://github.com/docker-library/postgres/issues/484 (clang-6.0 required, only available in stretch-backports)
 # TODO remove this once we hit buster+
-					echo 'deb http://deb.debian.org/debian stretch-backports main' >> /etc/apt/sources.list.d/pgdg.list; \
+					echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list.d/pgdg.list; \
 					;; \
 			esac; \
 			\
@@ -151,7 +151,6 @@ RUN set -ex; \
 	sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf; \
 	apt-get install -y --no-install-recommends \
 		"postgresql-$PG_MAJOR=$PG_VERSION" \
-		"postgresql-contrib-$PG_MAJOR=$PG_VERSION" \
 	; \
 	\
 	rm -rf /var/lib/apt/lists/*; \
@@ -182,7 +181,6 @@ RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PG
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/14/alpine/Dockerfile
+++ b/14/alpine/Dockerfile
@@ -17,9 +17,9 @@ ENV LANG en_US.utf8
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-ENV PG_MAJOR 9.5
-ENV PG_VERSION 9.5.25
-ENV PG_SHA256 7628c55eb23768a2c799c018988d8f2ab48ee3d80f5e11259938f7a935f0d603
+ENV PG_MAJOR 14
+ENV PG_VERSION 14beta1
+ENV PG_SHA256 c490ddf325444bd1381e1691e8e96814867a10b81ef73a74dc10323f7d143052
 
 RUN set -eux; \
 	\
@@ -46,6 +46,7 @@ RUN set -eux; \
 		libxml2-dev \
 		libxslt-dev \
 		linux-headers \
+		llvm10-dev clang g++ \
 		make \
 #		openldap-dev \
 		openssl-dev \
@@ -59,6 +60,7 @@ RUN set -eux; \
 #		tcl-dev \
 		util-linux-dev \
 		zlib-dev \
+		icu-dev \
 	; \
 	\
 	cd /usr/src/postgresql; \
@@ -102,6 +104,8 @@ RUN set -eux; \
 		--with-openssl \
 		--with-libxml \
 		--with-libxslt \
+		--with-icu \
+		--with-llvm \
 	; \
 	make -j "$(nproc)" world; \
 	make install-world; \
@@ -142,7 +146,6 @@ RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PG
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/14/docker-entrypoint.sh
+++ b/14/docker-entrypoint.sh
@@ -45,12 +45,12 @@ docker_create_db_directories() {
 	chmod 775 /var/run/postgresql || :
 
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
-	if [ -n "$POSTGRES_INITDB_XLOGDIR" ]; then
-		mkdir -p "$POSTGRES_INITDB_XLOGDIR"
+	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
+		mkdir -p "$POSTGRES_INITDB_WALDIR"
 		if [ "$user" = '0' ]; then
-			find "$POSTGRES_INITDB_XLOGDIR" \! -user postgres -exec chown postgres '{}' +
+			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
 		fi
-		chmod 700 "$POSTGRES_INITDB_XLOGDIR"
+		chmod 700 "$POSTGRES_INITDB_WALDIR"
 	fi
 
 	# allow the container to be started with `--user`
@@ -75,8 +75,8 @@ docker_init_database_dir() {
 		echo "postgres:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
 	fi
 
-	if [ -n "$POSTGRES_INITDB_XLOGDIR" ]; then
-		set -- --xlogdir "$POSTGRES_INITDB_XLOGDIR" "$@"
+	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
+		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
 	fi
 
 	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
@@ -285,7 +285,7 @@ _main() {
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
 			# then restart script as postgres user
-			exec su-exec postgres "$BASH_SOURCE" "$@"
+			exec gosu postgres "$BASH_SOURCE" "$@"
 		fi
 
 		# only run initialization on an empty data directory

--- a/update.sh
+++ b/update.sh
@@ -12,12 +12,9 @@ versions=( "${versions[@]%/}" )
 defaultDebianSuite='buster-slim'
 declare -A debianSuite=(
 	# https://github.com/docker-library/postgres/issues/582
-	[9.4]='stretch-slim'
-	[9.5]='stretch-slim'
 	[9.6]='stretch-slim'
 	[10]='stretch-slim'
 	[11]='stretch-slim'
-	[14]='bullseye-slim'
 )
 defaultAlpineVersion='3.13'
 declare -A alpineVersion=(
@@ -128,6 +125,9 @@ for version in "${versions[@]}"; do
 
 	if [ "$majorVersion" != '13' ]; then
 		sed -i -e '/DEBIAN_FRONTEND/d' "$version/Dockerfile"
+	fi
+	if [ "$majorVersion" -gt 11 ]; then
+		sed -i '/backwards compat/d' "$version/Dockerfile"
 	fi
 
 	# TODO figure out what to do with odd version numbers here, like release candidates

--- a/update.sh
+++ b/update.sh
@@ -17,6 +17,7 @@ declare -A debianSuite=(
 	[9.6]='stretch-slim'
 	[10]='stretch-slim'
 	[11]='stretch-slim'
+	[14]='bullseye-slim'
 )
 defaultAlpineVersion='3.13'
 declare -A alpineVersion=(


### PR DESCRIPTION
as I see:

"PostgreSQL 14 Beta 1 Released!"  ( 2021-05-20  )
https://www.postgresql.org/about/news/postgresql-14-beta-1-released-2213/

this is a minimal test - for adding
IMHO: the next debian version ( "bullseye" )  selected.  ( for a [postgis dockerimage](https://github.com/postgis/docker-postgis)  - it has a newer geos version  ) 

