### PR TITLE
Add missing contrib modules / pl extensions to alpine image

### DIFF
--- a/10/alpine/Dockerfile
+++ b/10/alpine/Dockerfile
@@ -45,14 +45,14 @@ RUN set -eux; \
 		dpkg-dev dpkg \
 		flex \
 		gcc \
-#		krb5-dev \
+		krb5-dev \
 		libc-dev \
 		libedit-dev \
 		libxml2-dev \
 		libxslt-dev \
 		linux-headers \
 		make \
-#		openldap-dev \
+		openldap-dev \
 		openssl-dev \
 # configure: error: prove not found
 		perl-utils \
@@ -96,9 +96,9 @@ RUN set -eux; \
 		--prefix=/usr/local \
 		--with-includes=/usr/local/include \
 		--with-libraries=/usr/local/lib \
-#		--with-krb5 \
-#		--with-gssapi \
-#		--with-ldap \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
 		--with-tcl \
 		--with-perl \
 		--with-python \

--- a/10/alpine/Dockerfile
+++ b/10/alpine/Dockerfile
@@ -58,10 +58,9 @@ RUN set -eux; \
 		perl-utils \
 # configure: error: Perl module IPC::Run is required to run TAP tests
 		perl-ipc-run \
-#		perl-dev \
-#		python-dev \
-#		python3-dev \
-#		tcl-dev \
+		perl-dev \
+		python3-dev \
+		tcl-dev \
 		util-linux-dev \
 		zlib-dev \
 # https://www.postgresql.org/docs/10/static/release-10.html#id-1.11.6.9.5.13
@@ -97,14 +96,12 @@ RUN set -eux; \
 		--prefix=/usr/local \
 		--with-includes=/usr/local/include \
 		--with-libraries=/usr/local/lib \
-		\
-# these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
 #		--with-krb5 \
 #		--with-gssapi \
 #		--with-ldap \
-#		--with-tcl \
-#		--with-perl \
-#		--with-python \
+		--with-tcl \
+		--with-perl \
+		--with-python \
 #		--with-pam \
 		--with-openssl \
 		--with-libxml \
@@ -120,6 +117,9 @@ RUN set -eux; \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+# Remove plperl, plpython and pltcl dependencies by default to save image size
+# To use the pl extensions, those have to be installed in a derived image
+			| grep -v -e perl -e python -e tcl \
 	)"; \
 	apk add --no-cache --virtual .postgresql-rundeps \
 		$runDeps \

--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -45,7 +45,7 @@ RUN set -eux; \
 		dpkg-dev dpkg \
 		flex \
 		gcc \
-#		krb5-dev \
+		krb5-dev \
 		libc-dev \
 		libedit-dev \
 		libxml2-dev \
@@ -53,7 +53,7 @@ RUN set -eux; \
 		linux-headers \
 		llvm11-dev clang g++ \
 		make \
-#		openldap-dev \
+		openldap-dev \
 		openssl-dev \
 # configure: error: prove not found
 		perl-utils \
@@ -97,9 +97,9 @@ RUN set -eux; \
 		--prefix=/usr/local \
 		--with-includes=/usr/local/include \
 		--with-libraries=/usr/local/lib \
-#		--with-krb5 \
-#		--with-gssapi \
-#		--with-ldap \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
 		--with-tcl \
 		--with-perl \
 		--with-python \

--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -59,10 +59,9 @@ RUN set -eux; \
 		perl-utils \
 # configure: error: Perl module IPC::Run is required to run TAP tests
 		perl-ipc-run \
-#		perl-dev \
-#		python-dev \
-#		python3-dev \
-#		tcl-dev \
+		perl-dev \
+		python3-dev \
+		tcl-dev \
 		util-linux-dev \
 		zlib-dev \
 # https://www.postgresql.org/docs/10/static/release-10.html#id-1.11.6.9.5.13
@@ -98,14 +97,12 @@ RUN set -eux; \
 		--prefix=/usr/local \
 		--with-includes=/usr/local/include \
 		--with-libraries=/usr/local/lib \
-		\
-# these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
 #		--with-krb5 \
 #		--with-gssapi \
 #		--with-ldap \
-#		--with-tcl \
-#		--with-perl \
-#		--with-python \
+		--with-tcl \
+		--with-perl \
+		--with-python \
 #		--with-pam \
 		--with-openssl \
 		--with-libxml \
@@ -122,6 +119,9 @@ RUN set -eux; \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+# Remove plperl, plpython and pltcl dependencies by default to save image size
+# To use the pl extensions, those have to be installed in a derived image
+			| grep -v -e perl -e python -e tcl \
 	)"; \
 	apk add --no-cache --virtual .postgresql-rundeps \
 		$runDeps \

--- a/12/alpine/Dockerfile
+++ b/12/alpine/Dockerfile
@@ -45,7 +45,7 @@ RUN set -eux; \
 		dpkg-dev dpkg \
 		flex \
 		gcc \
-#		krb5-dev \
+		krb5-dev \
 		libc-dev \
 		libedit-dev \
 		libxml2-dev \
@@ -53,7 +53,7 @@ RUN set -eux; \
 		linux-headers \
 		llvm11-dev clang g++ \
 		make \
-#		openldap-dev \
+		openldap-dev \
 		openssl-dev \
 # configure: error: prove not found
 		perl-utils \
@@ -97,9 +97,9 @@ RUN set -eux; \
 		--prefix=/usr/local \
 		--with-includes=/usr/local/include \
 		--with-libraries=/usr/local/lib \
-#		--with-krb5 \
-#		--with-gssapi \
-#		--with-ldap \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
 		--with-tcl \
 		--with-perl \
 		--with-python \

--- a/12/alpine/Dockerfile
+++ b/12/alpine/Dockerfile
@@ -59,10 +59,9 @@ RUN set -eux; \
 		perl-utils \
 # configure: error: Perl module IPC::Run is required to run TAP tests
 		perl-ipc-run \
-#		perl-dev \
-#		python-dev \
-#		python3-dev \
-#		tcl-dev \
+		perl-dev \
+		python3-dev \
+		tcl-dev \
 		util-linux-dev \
 		zlib-dev \
 # https://www.postgresql.org/docs/10/static/release-10.html#id-1.11.6.9.5.13
@@ -98,14 +97,12 @@ RUN set -eux; \
 		--prefix=/usr/local \
 		--with-includes=/usr/local/include \
 		--with-libraries=/usr/local/lib \
-		\
-# these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
 #		--with-krb5 \
 #		--with-gssapi \
 #		--with-ldap \
-#		--with-tcl \
-#		--with-perl \
-#		--with-python \
+		--with-tcl \
+		--with-perl \
+		--with-python \
 #		--with-pam \
 		--with-openssl \
 		--with-libxml \
@@ -122,6 +119,9 @@ RUN set -eux; \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+# Remove plperl, plpython and pltcl dependencies by default to save image size
+# To use the pl extensions, those have to be installed in a derived image
+			| grep -v -e perl -e python -e tcl \
 	)"; \
 	apk add --no-cache --virtual .postgresql-rundeps \
 		$runDeps \

--- a/13/alpine/Dockerfile
+++ b/13/alpine/Dockerfile
@@ -45,7 +45,7 @@ RUN set -eux; \
 		dpkg-dev dpkg \
 		flex \
 		gcc \
-#		krb5-dev \
+		krb5-dev \
 		libc-dev \
 		libedit-dev \
 		libxml2-dev \
@@ -53,7 +53,7 @@ RUN set -eux; \
 		linux-headers \
 		llvm11-dev clang g++ \
 		make \
-#		openldap-dev \
+		openldap-dev \
 		openssl-dev \
 # configure: error: prove not found
 		perl-utils \
@@ -97,9 +97,9 @@ RUN set -eux; \
 		--prefix=/usr/local \
 		--with-includes=/usr/local/include \
 		--with-libraries=/usr/local/lib \
-#		--with-krb5 \
-#		--with-gssapi \
-#		--with-ldap \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
 		--with-tcl \
 		--with-perl \
 		--with-python \

--- a/13/alpine/Dockerfile
+++ b/13/alpine/Dockerfile
@@ -59,10 +59,9 @@ RUN set -eux; \
 		perl-utils \
 # configure: error: Perl module IPC::Run is required to run TAP tests
 		perl-ipc-run \
-#		perl-dev \
-#		python-dev \
-#		python3-dev \
-#		tcl-dev \
+		perl-dev \
+		python3-dev \
+		tcl-dev \
 		util-linux-dev \
 		zlib-dev \
 # https://www.postgresql.org/docs/10/static/release-10.html#id-1.11.6.9.5.13
@@ -98,14 +97,12 @@ RUN set -eux; \
 		--prefix=/usr/local \
 		--with-includes=/usr/local/include \
 		--with-libraries=/usr/local/lib \
-		\
-# these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
 #		--with-krb5 \
 #		--with-gssapi \
 #		--with-ldap \
-#		--with-tcl \
-#		--with-perl \
-#		--with-python \
+		--with-tcl \
+		--with-perl \
+		--with-python \
 #		--with-pam \
 		--with-openssl \
 		--with-libxml \
@@ -122,6 +119,9 @@ RUN set -eux; \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+# Remove plperl, plpython and pltcl dependencies by default to save image size
+# To use the pl extensions, those have to be installed in a derived image
+			| grep -v -e perl -e python -e tcl \
 	)"; \
 	apk add --no-cache --virtual .postgresql-rundeps \
 		$runDeps \

--- a/14/alpine/Dockerfile
+++ b/14/alpine/Dockerfile
@@ -59,10 +59,9 @@ RUN set -eux; \
 		perl-utils \
 # configure: error: Perl module IPC::Run is required to run TAP tests
 		perl-ipc-run \
-#		perl-dev \
-#		python-dev \
-#		python3-dev \
-#		tcl-dev \
+		perl-dev \
+		python3-dev \
+		tcl-dev \
 		util-linux-dev \
 		zlib-dev \
 # https://www.postgresql.org/docs/10/static/release-10.html#id-1.11.6.9.5.13
@@ -100,14 +99,12 @@ RUN set -eux; \
 		--prefix=/usr/local \
 		--with-includes=/usr/local/include \
 		--with-libraries=/usr/local/lib \
-		\
-# these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
 #		--with-krb5 \
 #		--with-gssapi \
 #		--with-ldap \
-#		--with-tcl \
-#		--with-perl \
-#		--with-python \
+		--with-tcl \
+		--with-perl \
+		--with-python \
 #		--with-pam \
 		--with-openssl \
 		--with-libxml \
@@ -125,6 +122,9 @@ RUN set -eux; \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+# Remove plperl, plpython and pltcl dependencies by default to save image size
+# To use the pl extensions, those have to be installed in a derived image
+			| grep -v -e perl -e python -e tcl \
 	)"; \
 	apk add --no-cache --virtual .postgresql-rundeps \
 		$runDeps \

--- a/14/alpine/Dockerfile
+++ b/14/alpine/Dockerfile
@@ -45,7 +45,7 @@ RUN set -eux; \
 		dpkg-dev dpkg \
 		flex \
 		gcc \
-#		krb5-dev \
+		krb5-dev \
 		libc-dev \
 		libedit-dev \
 		libxml2-dev \
@@ -53,7 +53,7 @@ RUN set -eux; \
 		linux-headers \
 		llvm11-dev clang g++ \
 		make \
-#		openldap-dev \
+		openldap-dev \
 		openssl-dev \
 # configure: error: prove not found
 		perl-utils \
@@ -99,9 +99,9 @@ RUN set -eux; \
 		--prefix=/usr/local \
 		--with-includes=/usr/local/include \
 		--with-libraries=/usr/local/lib \
-#		--with-krb5 \
-#		--with-gssapi \
-#		--with-ldap \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
 		--with-tcl \
 		--with-perl \
 		--with-python \

--- a/9.6/alpine/Dockerfile
+++ b/9.6/alpine/Dockerfile
@@ -58,10 +58,9 @@ RUN set -eux; \
 		perl-utils \
 # configure: error: Perl module IPC::Run is required to run TAP tests
 		perl-ipc-run \
-#		perl-dev \
-#		python-dev \
-#		python3-dev \
-#		tcl-dev \
+		perl-dev \
+		python3-dev \
+		tcl-dev \
 		util-linux-dev \
 		zlib-dev \
 	; \
@@ -95,14 +94,12 @@ RUN set -eux; \
 		--prefix=/usr/local \
 		--with-includes=/usr/local/include \
 		--with-libraries=/usr/local/lib \
-		\
-# these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
 #		--with-krb5 \
 #		--with-gssapi \
 #		--with-ldap \
-#		--with-tcl \
-#		--with-perl \
-#		--with-python \
+		--with-tcl \
+		--with-perl \
+		--with-python \
 #		--with-pam \
 		--with-openssl \
 		--with-libxml \
@@ -117,6 +114,9 @@ RUN set -eux; \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+# Remove plperl, plpython and pltcl dependencies by default to save image size
+# To use the pl extensions, those have to be installed in a derived image
+			| grep -v -e perl -e python -e tcl \
 	)"; \
 	apk add --no-cache --virtual .postgresql-rundeps \
 		$runDeps \

--- a/9.6/alpine/Dockerfile
+++ b/9.6/alpine/Dockerfile
@@ -45,14 +45,14 @@ RUN set -eux; \
 		dpkg-dev dpkg \
 		flex \
 		gcc \
-#		krb5-dev \
+		krb5-dev \
 		libc-dev \
 		libedit-dev \
 		libxml2-dev \
 		libxslt-dev \
 		linux-headers \
 		make \
-#		openldap-dev \
+		openldap-dev \
 		openssl-dev \
 # configure: error: prove not found
 		perl-utils \
@@ -94,9 +94,9 @@ RUN set -eux; \
 		--prefix=/usr/local \
 		--with-includes=/usr/local/include \
 		--with-libraries=/usr/local/lib \
-#		--with-krb5 \
-#		--with-gssapi \
-#		--with-ldap \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
 		--with-tcl \
 		--with-perl \
 		--with-python \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -39,7 +39,7 @@ RUN set -eux; \
 		dpkg-dev dpkg \
 		flex \
 		gcc \
-#		krb5-dev \
+		krb5-dev \
 		libc-dev \
 		libedit-dev \
 		libxml2-dev \
@@ -49,7 +49,7 @@ RUN set -eux; \
 		llvm11-dev clang g++ \
 {{ ) else "" end -}}
 		make \
-#		openldap-dev \
+		openldap-dev \
 		openssl-dev \
 # configure: error: prove not found
 		perl-utils \
@@ -99,9 +99,9 @@ RUN set -eux; \
 		--prefix=/usr/local \
 		--with-includes=/usr/local/include \
 		--with-libraries=/usr/local/lib \
-#		--with-krb5 \
-#		--with-gssapi \
-#		--with-ldap \
+		--with-krb5 \
+		--with-gssapi \
+		--with-ldap \
 		--with-tcl \
 		--with-perl \
 		--with-python \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -55,10 +55,9 @@ RUN set -eux; \
 		perl-utils \
 # configure: error: Perl module IPC::Run is required to run TAP tests
 		perl-ipc-run \
-#		perl-dev \
-#		python-dev \
-#		python3-dev \
-#		tcl-dev \
+		perl-dev \
+		python3-dev \
+		tcl-dev \
 		util-linux-dev \
 		zlib-dev \
 {{ if .major >= 10 then ( -}}
@@ -100,14 +99,12 @@ RUN set -eux; \
 		--prefix=/usr/local \
 		--with-includes=/usr/local/include \
 		--with-libraries=/usr/local/lib \
-		\
-# these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
 #		--with-krb5 \
 #		--with-gssapi \
 #		--with-ldap \
-#		--with-tcl \
-#		--with-perl \
-#		--with-python \
+		--with-tcl \
+		--with-perl \
+		--with-python \
 #		--with-pam \
 		--with-openssl \
 		--with-libxml \
@@ -131,6 +128,9 @@ RUN set -eux; \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+# Remove plperl, plpython and pltcl dependencies by default to save image size
+# To use the pl extensions, those have to be installed in a derived image
+			| grep -v -e perl -e python -e tcl \
 	)"; \
 	apk add --no-cache --virtual .postgresql-rundeps \
 		$runDeps \


### PR DESCRIPTION
The readme on dockerhub says:

> When using the Alpine variants, any postgres extension not listed in postgres-contrib will need to be compiled in your own image (again, see github.com/postgis/docker-postgis for a concrete example).

However, not all extensions in contrib are available. The language extension `plperl`, `plpython` and `pltcl`, as well as related contrib modules (e.g. `hstore_*`, `jsonb_*`, ...) are missing.

Only in very rare cases, when the postgres version matches the one distributed in the current alpine distribution, one can install e.g. `plpython` via `apk add postgresql-plpython3` (with a bit of moving files around to their proper location). However, this is not sustainable: It currently works for pg 13.x on alpine 3.14, but not for pg 14.x anymore.

Compiling those extensions from source kind of defeats the purpose of deriving from this image in the first place.

Currently, those extensions seem to be left out on purpose:

https://github.com/docker-library/postgres/blob/a11e908fb50cacb6192d1db93dcf911bc1a724e6/Dockerfile-alpine.template#L104-L110

I investigated the potential increase in image size a little bit. It seems like the biggest chunk results from additional dependencies in perl, python and tcl. However, those can be avoided, if we build the extension, but then remove the dependencies for them. This means the above mentioned extensions will only be usable after installing the dependencies in a derived image again - but that's already a **huge** step forward.

As an example, using `plpython` would be as simple as:

```dockerfile
FROM postgres:14-alpine
RUN apk add --no-cache python3
```

I looked at image size in 4 cases:
- `master`: current master branch
- `+PLfull`: compiled language extension, but kept the dependencies
- `+PL`: compiled language extensions, but removed dependencies
- `+PL+auth`: same as before, but also compiled `--with-krb5`, `--with-gssapi` and `--with-ldap`

The last one was just because those were commented out, too, and I wondered what it would cost to enable them now.
 
postgres | master | +PLfull | +PL | +PL+auth
-- | -- | -- | -- | --
14.1-alpine | 195 | 280 | 196 | 199
13.5-alpine | 192 | 276 | 192 | 195
12.9-alpine | 190 | 275 | 191 | 194
11.14-alpine | 188 | 273 | 189 | 192
10.19-alpine | 73 | 157 | 73 | 76
9.6.24-alpine | 37 | 92 | 51 | 54

The data shows that indeed the biggest chunk comes from perl, python and tcl. The increase in image size for the other two cases however is really small.

I suggest to enable both the language extensions as well as `--with-krb5`, `--with-gssapi` and `--with-ldap`, but leave out the 3 major dependencies to keep image size small. This will make the alpine image much more usable.
