### PR TITLE
update GOSU to 1.14

### DIFF
--- a/10/bullseye/Dockerfile
+++ b/10/bullseye/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux; \
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.12
+ENV GOSU_VERSION 1.14
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \

--- a/10/stretch/Dockerfile
+++ b/10/stretch/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux; \
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.12
+ENV GOSU_VERSION 1.14
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux; \
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.12
+ENV GOSU_VERSION 1.14
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \

--- a/11/stretch/Dockerfile
+++ b/11/stretch/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux; \
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.12
+ENV GOSU_VERSION 1.14
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \

--- a/12/bullseye/Dockerfile
+++ b/12/bullseye/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux; \
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.12
+ENV GOSU_VERSION 1.14
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \

--- a/13/bullseye/Dockerfile
+++ b/13/bullseye/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux; \
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.12
+ENV GOSU_VERSION 1.14
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \

--- a/14/bullseye/Dockerfile
+++ b/14/bullseye/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux; \
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.12
+ENV GOSU_VERSION 1.14
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \

--- a/9.6/bullseye/Dockerfile
+++ b/9.6/bullseye/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux; \
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.12
+ENV GOSU_VERSION 1.14
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \

--- a/9.6/stretch/Dockerfile
+++ b/9.6/stretch/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux; \
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.12
+ENV GOSU_VERSION 1.14
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -22,7 +22,7 @@ RUN set -eux; \
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.12
+ENV GOSU_VERSION 1.14
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \


### PR DESCRIPTION
Signed-off-by: daniel sutton <daniel@ducksecops.uk>

Upgradet GOSU 1.14 from prevous GOSU 1.12. Newer version is based on GO 1.16.7 which is supported.