### PR TITLE
[FIX] Dockerfile

### DIFF
--- a/12/alpine/Dockerfile
+++ b/12/alpine/Dockerfile
@@ -155,6 +155,7 @@ RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PG
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod 777 /usr/local/bin/docker-entrypoint.sh && ln -s /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/12/bullseye/Dockerfile
+++ b/12/bullseye/Dockerfile
@@ -180,6 +180,7 @@ RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PG
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod 777 /usr/local/bin/docker-entrypoint.sh && ln -s /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL


### PR DESCRIPTION
Solved issue appear when running the postgres container
```console
docker: Error response from daemon: oci runtime error: container_linux.go:247: starting container process caused "exec: \"docker-entrypoint.sh\": executable file not found in $PATH".

```