### PR TITLE
Fix new zstd support for alpine images

### DIFF
--- a/10/alpine/Dockerfile
+++ b/10/alpine/Dockerfile
@@ -61,7 +61,6 @@ RUN set -eux; \
 		tcl-dev \
 		util-linux-dev \
 		zlib-dev \
-		zstd \
 # https://www.postgresql.org/docs/10/static/release-10.html#id-1.11.6.9.5.13
 		icu-dev \
 	; \
@@ -127,6 +126,7 @@ RUN set -eux; \
 # tzdata is optional, but only adds around 1Mb to image size and is recommended by Django documentation:
 # https://docs.djangoproject.com/en/1.10/ref/databases/#optimizing-postgresql-s-configuration
 		tzdata \
+		zstd \
 	; \
 	apk del --no-network .build-deps; \
 	cd /; \

--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -62,7 +62,6 @@ RUN set -eux; \
 		tcl-dev \
 		util-linux-dev \
 		zlib-dev \
-		zstd \
 # https://www.postgresql.org/docs/10/static/release-10.html#id-1.11.6.9.5.13
 		icu-dev \
 	; \
@@ -129,6 +128,7 @@ RUN set -eux; \
 # tzdata is optional, but only adds around 1Mb to image size and is recommended by Django documentation:
 # https://docs.djangoproject.com/en/1.10/ref/databases/#optimizing-postgresql-s-configuration
 		tzdata \
+		zstd \
 	; \
 	apk del --no-network .build-deps; \
 	cd /; \

--- a/12/alpine/Dockerfile
+++ b/12/alpine/Dockerfile
@@ -62,7 +62,6 @@ RUN set -eux; \
 		tcl-dev \
 		util-linux-dev \
 		zlib-dev \
-		zstd \
 # https://www.postgresql.org/docs/10/static/release-10.html#id-1.11.6.9.5.13
 		icu-dev \
 	; \
@@ -129,6 +128,7 @@ RUN set -eux; \
 # tzdata is optional, but only adds around 1Mb to image size and is recommended by Django documentation:
 # https://docs.djangoproject.com/en/1.10/ref/databases/#optimizing-postgresql-s-configuration
 		tzdata \
+		zstd \
 	; \
 	apk del --no-network .build-deps; \
 	cd /; \

--- a/13/alpine/Dockerfile
+++ b/13/alpine/Dockerfile
@@ -62,7 +62,6 @@ RUN set -eux; \
 		tcl-dev \
 		util-linux-dev \
 		zlib-dev \
-		zstd \
 # https://www.postgresql.org/docs/10/static/release-10.html#id-1.11.6.9.5.13
 		icu-dev \
 	; \
@@ -129,6 +128,7 @@ RUN set -eux; \
 # tzdata is optional, but only adds around 1Mb to image size and is recommended by Django documentation:
 # https://docs.djangoproject.com/en/1.10/ref/databases/#optimizing-postgresql-s-configuration
 		tzdata \
+		zstd \
 	; \
 	apk del --no-network .build-deps; \
 	cd /; \

--- a/14/alpine/Dockerfile
+++ b/14/alpine/Dockerfile
@@ -62,7 +62,6 @@ RUN set -eux; \
 		tcl-dev \
 		util-linux-dev \
 		zlib-dev \
-		zstd \
 # https://www.postgresql.org/docs/10/static/release-10.html#id-1.11.6.9.5.13
 		icu-dev \
 # https://www.postgresql.org/docs/14/release-14.html#id-1.11.6.5.5.3.7
@@ -132,6 +131,7 @@ RUN set -eux; \
 # tzdata is optional, but only adds around 1Mb to image size and is recommended by Django documentation:
 # https://docs.djangoproject.com/en/1.10/ref/databases/#optimizing-postgresql-s-configuration
 		tzdata \
+		zstd \
 	; \
 	apk del --no-network .build-deps; \
 	cd /; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -58,7 +58,6 @@ RUN set -eux; \
 		tcl-dev \
 		util-linux-dev \
 		zlib-dev \
-		zstd \
 # https://www.postgresql.org/docs/10/static/release-10.html#id-1.11.6.9.5.13
 		icu-dev \
 {{ if .major >= 14 then ( -}}
@@ -134,6 +133,7 @@ RUN set -eux; \
 # tzdata is optional, but only adds around 1Mb to image size and is recommended by Django documentation:
 # https://docs.djangoproject.com/en/1.10/ref/databases/#optimizing-postgresql-s-configuration
 		tzdata \
+		zstd \
 	; \
 	apk del --no-network .build-deps; \
 	cd /; \


### PR DESCRIPTION
In e8ebf74e50128123a8d0220b85e357ef2d73a7ec zstd was installed as build dependency and thus does not end up in the final image which in turn renders docker-entrypoint.sh broken when using *.sql.zst files.