### PR TITLE
pg >=15 alpine: Enable Zstandard builds "--with-zstd"

### DIFF
--- a/15/alpine/Dockerfile
+++ b/15/alpine/Dockerfile
@@ -66,6 +66,8 @@ RUN set -eux; \
 		icu-dev \
 # https://www.postgresql.org/docs/14/release-14.html#id-1.11.6.5.5.3.7
 		lz4-dev \
+# https://www.postgresql.org/docs/15/release-15.html "--with-zstd to enable Zstandard builds"
+		zstd-dev \
 	; \
 	\
 	cd /usr/src/postgresql; \
@@ -110,6 +112,7 @@ RUN set -eux; \
 		--with-icu \
 		--with-llvm \
 		--with-lz4 \
+		--with-zstd \
 	; \
 	make -j "$(nproc)" world; \
 	make install-world; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -64,6 +64,10 @@ RUN set -eux; \
 # https://www.postgresql.org/docs/14/release-14.html#id-1.11.6.5.5.3.7
 		lz4-dev \
 {{ ) else "" end -}}
+{{ if .major >= 15 then ( -}}
+# https://www.postgresql.org/docs/15/release-15.html "--with-zstd to enable Zstandard builds"
+		zstd-dev \
+{{ ) else "" end -}}
 	; \
 	\
 	cd /usr/src/postgresql; \
@@ -111,6 +115,9 @@ RUN set -eux; \
 {{ ) else "" end -}}
 {{ if .major >= 14 then ( -}}
 		--with-lz4 \
+{{ ) else "" end -}}
+{{ if .major >= 15 then ( -}}
+		--with-zstd \
 {{ ) else "" end -}}
 	; \
 	make -j "$(nproc)" world; \


### PR DESCRIPTION
pg >=15 alpine: **"Add configure option --with-zstd to enable Zstandard builds"**
* https://www.postgresql.org/docs/15/release-15.html 

NOW: Test `postgres:15beta1-alpine` ( current )

```
docker run --name current_pgalpine15 -e POSTGRES_PASSWORD=pi31415926 -d postgres:15beta1-alpine -c wal_compression=zstd

# .... Error in the logs
2022-06-30 06:48:41.233 GMT [31] FATAL:  invalid value for parameter "wal_compression": "zstd"
2022-06-30 06:48:41.233 GMT [31] HINT:  Available values: pglz, lz4, on, off.
```

PROPOSAL: Test pgalpine15_zstd 

```bash
$ cd ./15/alpine
$ docker build -t pgalpine15_zstd .
$ docker run --name pgalpine15_zstd -e POSTGRES_PASSWORD=pi31415926 -d pgalpine15_zstd -c wal_compression=zstd
$ docker exec -ti pgalpine15_zstd psql -U postgres -c "SHOW wal_compression;"
 wal_compression 
-----------------
 zstd
(1 row)
```

Size difference:
```
$ docker images | grep -E "(15beta1-alpine|pgalpine15_zstd)"
pgalpine15_zstd                         latest                       b5e422128289   46 minutes ago   218MB
postgres                                15beta1-alpine               0ee202fdba91   8 days ago       218MB
```

`./update.sh` test
* only the `15/alpine/Dockerfile` has changed