### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/12/alpine/docker-entrypoint.sh
+++ b/12/alpine/docker-entrypoint.sh
@@ -336,6 +336,9 @@ _main() {
 			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
 			echo
 		fi
+		docker_temp_server_start "$@"
+		docker_process_init_files /always-initdb.d/*
+		docker_temp_server_stop
 	fi
 
 	exec "$@"

--- a/12/alpine/docker-entrypoint.sh
+++ b/12/alpine/docker-entrypoint.sh
@@ -306,7 +306,7 @@ _main() {
 			# then restart script as postgres user
 			exec su-exec postgres "$BASH_SOURCE" "$@"
 		fi
-
+		docker_temp_server_start "$@"
 		# only run initialization on an empty data directory
 		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
 			docker_verify_minimum_env
@@ -320,12 +320,10 @@ _main() {
 			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
 			# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
 			export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
-			docker_temp_server_start "$@"
 
 			docker_setup_db
 			docker_process_init_files /docker-entrypoint-initdb.d/*
 
-			docker_temp_server_stop
 			unset PGPASSWORD
 
 			echo
@@ -336,7 +334,6 @@ _main() {
 			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
 			echo
 		fi
-		docker_temp_server_start "$@"
 		docker_process_init_files /always-initdb.d/*
 		docker_temp_server_stop
 	fi


### PR DESCRIPTION
I just made the same changes on my own and got adequate, expected and logical behavior. I don't mean to be rude, but I just want to ask: why aren't these changes still in the original postgres image?
After all, this is a logical behavior - the user, if he needs it, adds his always-init.sh script to the always-init directory, if not needed - he does not add anything and postgres simply does nothing "always" (regardless of external conditions).