### PR TITLE
Add nss_wrapper to alpine images to run container with different user

### DIFF
--- a/10/alpine/Dockerfile
+++ b/10/alpine/Dockerfile
@@ -120,8 +120,11 @@ RUN set -eux; \
 			| grep -v -e perl -e python -e tcl \
 	)"; \
 	apk add --no-cache --virtual .postgresql-rundeps \
+		# nss_wrapper is currently only available in testing
+		--repository https://dl-cdn.alpinelinux.org/alpine/edge/testing \
 		$runDeps \
 		bash \
+		nss_wrapper \
 		su-exec \
 		tzdata \
 		zstd \

--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -122,8 +122,11 @@ RUN set -eux; \
 			| grep -v -e perl -e python -e tcl \
 	)"; \
 	apk add --no-cache --virtual .postgresql-rundeps \
+		# nss_wrapper is currently only available in testing
+		--repository https://dl-cdn.alpinelinux.org/alpine/edge/testing \
 		$runDeps \
 		bash \
+		nss_wrapper \
 		su-exec \
 		tzdata \
 		zstd \

--- a/12/alpine/Dockerfile
+++ b/12/alpine/Dockerfile
@@ -122,8 +122,11 @@ RUN set -eux; \
 			| grep -v -e perl -e python -e tcl \
 	)"; \
 	apk add --no-cache --virtual .postgresql-rundeps \
+		# nss_wrapper is currently only available in testing
+		--repository https://dl-cdn.alpinelinux.org/alpine/edge/testing \
 		$runDeps \
 		bash \
+		nss_wrapper \
 		su-exec \
 		tzdata \
 		zstd \

--- a/13/alpine/Dockerfile
+++ b/13/alpine/Dockerfile
@@ -122,8 +122,11 @@ RUN set -eux; \
 			| grep -v -e perl -e python -e tcl \
 	)"; \
 	apk add --no-cache --virtual .postgresql-rundeps \
+		# nss_wrapper is currently only available in testing
+		--repository https://dl-cdn.alpinelinux.org/alpine/edge/testing \
 		$runDeps \
 		bash \
+		nss_wrapper \
 		su-exec \
 		tzdata \
 		zstd \

--- a/14/alpine/Dockerfile
+++ b/14/alpine/Dockerfile
@@ -125,8 +125,11 @@ RUN set -eux; \
 			| grep -v -e perl -e python -e tcl \
 	)"; \
 	apk add --no-cache --virtual .postgresql-rundeps \
+		# nss_wrapper is currently only available in testing
+		--repository https://dl-cdn.alpinelinux.org/alpine/edge/testing \
 		$runDeps \
 		bash \
+		nss_wrapper \
 		su-exec \
 		tzdata \
 		zstd \

--- a/15/alpine/Dockerfile
+++ b/15/alpine/Dockerfile
@@ -128,8 +128,11 @@ RUN set -eux; \
 			| grep -v -e perl -e python -e tcl \
 	)"; \
 	apk add --no-cache --virtual .postgresql-rundeps \
+		# nss_wrapper is currently only available in testing
+		--repository https://dl-cdn.alpinelinux.org/alpine/edge/testing \
 		$runDeps \
 		bash \
+		nss_wrapper \
 		su-exec \
 		tzdata \
 		zstd \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -134,8 +134,11 @@ RUN set -eux; \
 			| grep -v -e perl -e python -e tcl \
 	)"; \
 	apk add --no-cache --virtual .postgresql-rundeps \
+		# nss_wrapper is currently only available in testing
+		--repository https://dl-cdn.alpinelinux.org/alpine/edge/testing \
 		$runDeps \
 		bash \
+		nss_wrapper \
 		su-exec \
 		tzdata \
 		zstd \


### PR DESCRIPTION
`nss_wrapper` is now available in alpine's `edge/testing` repo: https://pkgs.alpinelinux.org/packages?name=nss_wrapper&branch=edge&repo=&arch=

Adding this to the alpine variants will allow to run those with different user ids, too - similar to the debian images.

Ref #253 and #359.

The [docs](https://github.com/docker-library/docs/blob/master/postgres/README.md#arbitrary---user-notes) will need adjustment, too.