### PR TITLE
Skip unavailable nss_wrapper on ppc64le

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -124,12 +124,14 @@ RUN set -eux; \
 	apk add --no-cache --virtual .postgresql-rundeps \
 		$runDeps \
 		bash \
-		nss_wrapper \
 		su-exec \
 		tzdata \
 		zstd \
 # https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.16.0#ICU_data_split
 		icu-data-full \
+# nss_wrapper is not availble on ppc64le: "test case segfaults in ppc64le"
+# https://git.alpinelinux.org/aports/commit/testing/nss_wrapper/APKBUILD?h=3.17-stable&id=94d81ceeb58cff448d489bbcbe9a6d40c9991663
+		$([ "$(apk --print-arch)" != 'ppc64le' ] && echo 'nss_wrapper') \
 	; \
 	apk del --no-network .build-deps; \
 	cd /; \

--- a/12/alpine/Dockerfile
+++ b/12/alpine/Dockerfile
@@ -124,12 +124,14 @@ RUN set -eux; \
 	apk add --no-cache --virtual .postgresql-rundeps \
 		$runDeps \
 		bash \
-		nss_wrapper \
 		su-exec \
 		tzdata \
 		zstd \
 # https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.16.0#ICU_data_split
 		icu-data-full \
+# nss_wrapper is not availble on ppc64le: "test case segfaults in ppc64le"
+# https://git.alpinelinux.org/aports/commit/testing/nss_wrapper/APKBUILD?h=3.17-stable&id=94d81ceeb58cff448d489bbcbe9a6d40c9991663
+		$([ "$(apk --print-arch)" != 'ppc64le' ] && echo 'nss_wrapper') \
 	; \
 	apk del --no-network .build-deps; \
 	cd /; \

--- a/13/alpine/Dockerfile
+++ b/13/alpine/Dockerfile
@@ -124,12 +124,14 @@ RUN set -eux; \
 	apk add --no-cache --virtual .postgresql-rundeps \
 		$runDeps \
 		bash \
-		nss_wrapper \
 		su-exec \
 		tzdata \
 		zstd \
 # https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.16.0#ICU_data_split
 		icu-data-full \
+# nss_wrapper is not availble on ppc64le: "test case segfaults in ppc64le"
+# https://git.alpinelinux.org/aports/commit/testing/nss_wrapper/APKBUILD?h=3.17-stable&id=94d81ceeb58cff448d489bbcbe9a6d40c9991663
+		$([ "$(apk --print-arch)" != 'ppc64le' ] && echo 'nss_wrapper') \
 	; \
 	apk del --no-network .build-deps; \
 	cd /; \

--- a/14/alpine/Dockerfile
+++ b/14/alpine/Dockerfile
@@ -127,12 +127,14 @@ RUN set -eux; \
 	apk add --no-cache --virtual .postgresql-rundeps \
 		$runDeps \
 		bash \
-		nss_wrapper \
 		su-exec \
 		tzdata \
 		zstd \
 # https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.16.0#ICU_data_split
 		icu-data-full \
+# nss_wrapper is not availble on ppc64le: "test case segfaults in ppc64le"
+# https://git.alpinelinux.org/aports/commit/testing/nss_wrapper/APKBUILD?h=3.17-stable&id=94d81ceeb58cff448d489bbcbe9a6d40c9991663
+		$([ "$(apk --print-arch)" != 'ppc64le' ] && echo 'nss_wrapper') \
 	; \
 	apk del --no-network .build-deps; \
 	cd /; \

--- a/15/alpine/Dockerfile
+++ b/15/alpine/Dockerfile
@@ -130,12 +130,14 @@ RUN set -eux; \
 	apk add --no-cache --virtual .postgresql-rundeps \
 		$runDeps \
 		bash \
-		nss_wrapper \
 		su-exec \
 		tzdata \
 		zstd \
 # https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.16.0#ICU_data_split
 		icu-data-full \
+# nss_wrapper is not availble on ppc64le: "test case segfaults in ppc64le"
+# https://git.alpinelinux.org/aports/commit/testing/nss_wrapper/APKBUILD?h=3.17-stable&id=94d81ceeb58cff448d489bbcbe9a6d40c9991663
+		$([ "$(apk --print-arch)" != 'ppc64le' ] && echo 'nss_wrapper') \
 	; \
 	apk del --no-network .build-deps; \
 	cd /; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -136,12 +136,14 @@ RUN set -eux; \
 	apk add --no-cache --virtual .postgresql-rundeps \
 		$runDeps \
 		bash \
-		nss_wrapper \
 		su-exec \
 		tzdata \
 		zstd \
 # https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.16.0#ICU_data_split
 		icu-data-full \
+# nss_wrapper is not availble on ppc64le: "test case segfaults in ppc64le"
+# https://git.alpinelinux.org/aports/commit/testing/nss_wrapper/APKBUILD?h=3.17-stable&id=94d81ceeb58cff448d489bbcbe9a6d40c9991663
+		$([ "$(apk --print-arch)" != 'ppc64le' ] && echo 'nss_wrapper') \
 	; \
 	apk del --no-network .build-deps; \
 	cd /; \


### PR DESCRIPTION
This will fix the current failing builds on ppc64le:

```console
+ apk add --no-cache --virtual .postgresql-rundeps so:libLLVM-15.so so:libc.musl-ppc64le.so.1 so:libcrypto.so.3 so:libedit.so.0 so:libgcc_s.so.1 so:libgssapi_krb5.so.2 so:libicui18n.so.72 so:libicuuc.so.72 so:libldap.so.2 so:libssl.so.3 so:libstdc++.so.6 so:libuuid.so.1 so:libxml2.so.2 so:libxslt.so.1 so:libz.so.1 bash nss_wrapper su-exec tzdata zstd icu-data-full
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/main/ppc64le/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/community/ppc64le/APKINDEX.tar.gz
ERROR: unable to select packages:
  .postgresql-rundeps-20221222.204533:
    masked in: cache
    satisfies: world[.postgresql-rundeps=20221222.204533]
  nss_wrapper (no such package):
    required by: .postgresql-rundeps-20221222.204533[nss_wrapper]
```

Related to https://github.com/docker-library/postgres/pull/1018