### PR TITLE
Downgrade llvm to 15 to fix jit support

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -26,6 +26,10 @@ ENV PG_MAJOR 11
 ENV PG_VERSION 11.20
 ENV PG_SHA256 3d7c8882f64a7e98534a044257dfee7abad77a5b7da12508d85d722b98b5acce
 
+ENV DOCKER_PG_LLVM_DEPS \
+		llvm15-dev \
+		clang15
+
 RUN set -eux; \
 	\
 	wget -O postgresql.tar.bz2 "https://ftp.postgresql.org/pub/source/v$PG_VERSION/postgresql-$PG_VERSION.tar.bz2"; \
@@ -40,10 +44,12 @@ RUN set -eux; \
 	rm postgresql.tar.bz2; \
 	\
 	apk add --no-cache --virtual .build-deps \
+		$DOCKER_PG_LLVM_DEPS \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
 		flex \
+		g++ \
 		gcc \
 		krb5-dev \
 		libc-dev \
@@ -51,7 +57,6 @@ RUN set -eux; \
 		libxml2-dev \
 		libxslt-dev \
 		linux-headers \
-		llvm-dev clang g++ \
 		make \
 		openldap-dev \
 		openssl-dev \
@@ -76,6 +81,12 @@ RUN set -eux; \
 # explicitly update autoconf config.guess and config.sub so they support more arches/libcs
 	wget -O config/config.guess 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess?id=7d3d27baf8107b630586c962c057e22149653deb'; \
 	wget -O config/config.sub 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub?id=7d3d27baf8107b630586c962c057e22149653deb'; \
+	\
+# https://git.alpinelinux.org/aports/tree/community/postgresql12/APKBUILD?h=3.18-stable&id=a470294e6d6ca7059e41c54769b7c3c26ec901d4#n158
+	export LLVM_CONFIG="/usr/lib/llvm15/bin/llvm-config"; \
+# https://git.alpinelinux.org/aports/tree/community/postgresql12/APKBUILD?h=3.18-stable&id=a470294e6d6ca7059e41c54769b7c3c26ec901d4#n163
+	export CLANG=clang-15; \
+	\
 # configure options taken from:
 # https://anonscm.debian.org/cgit/pkg-postgresql/postgresql.git/tree/debian/rules?h=9.5
 	./configure \

--- a/12/alpine/Dockerfile
+++ b/12/alpine/Dockerfile
@@ -26,6 +26,10 @@ ENV PG_MAJOR 12
 ENV PG_VERSION 12.15
 ENV PG_SHA256 bb5206e2864c1c4579938b96ea6096d155f22abf2d2cc2aa57571e3c4cb12b36
 
+ENV DOCKER_PG_LLVM_DEPS \
+		llvm15-dev \
+		clang15
+
 RUN set -eux; \
 	\
 	wget -O postgresql.tar.bz2 "https://ftp.postgresql.org/pub/source/v$PG_VERSION/postgresql-$PG_VERSION.tar.bz2"; \
@@ -40,10 +44,12 @@ RUN set -eux; \
 	rm postgresql.tar.bz2; \
 	\
 	apk add --no-cache --virtual .build-deps \
+		$DOCKER_PG_LLVM_DEPS \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
 		flex \
+		g++ \
 		gcc \
 		krb5-dev \
 		libc-dev \
@@ -51,7 +57,6 @@ RUN set -eux; \
 		libxml2-dev \
 		libxslt-dev \
 		linux-headers \
-		llvm-dev clang g++ \
 		make \
 		openldap-dev \
 		openssl-dev \
@@ -76,6 +81,12 @@ RUN set -eux; \
 # explicitly update autoconf config.guess and config.sub so they support more arches/libcs
 	wget -O config/config.guess 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess?id=7d3d27baf8107b630586c962c057e22149653deb'; \
 	wget -O config/config.sub 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub?id=7d3d27baf8107b630586c962c057e22149653deb'; \
+	\
+# https://git.alpinelinux.org/aports/tree/community/postgresql12/APKBUILD?h=3.18-stable&id=a470294e6d6ca7059e41c54769b7c3c26ec901d4#n158
+	export LLVM_CONFIG="/usr/lib/llvm15/bin/llvm-config"; \
+# https://git.alpinelinux.org/aports/tree/community/postgresql12/APKBUILD?h=3.18-stable&id=a470294e6d6ca7059e41c54769b7c3c26ec901d4#n163
+	export CLANG=clang-15; \
+	\
 # configure options taken from:
 # https://anonscm.debian.org/cgit/pkg-postgresql/postgresql.git/tree/debian/rules?h=9.5
 	./configure \

--- a/13/alpine/Dockerfile
+++ b/13/alpine/Dockerfile
@@ -26,6 +26,10 @@ ENV PG_MAJOR 13
 ENV PG_VERSION 13.11
 ENV PG_SHA256 4992ff647203566b670d4e54dc5317499a26856c93576d0ea951bdf6bee50bfb
 
+ENV DOCKER_PG_LLVM_DEPS \
+		llvm15-dev \
+		clang15
+
 RUN set -eux; \
 	\
 	wget -O postgresql.tar.bz2 "https://ftp.postgresql.org/pub/source/v$PG_VERSION/postgresql-$PG_VERSION.tar.bz2"; \
@@ -40,10 +44,12 @@ RUN set -eux; \
 	rm postgresql.tar.bz2; \
 	\
 	apk add --no-cache --virtual .build-deps \
+		$DOCKER_PG_LLVM_DEPS \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
 		flex \
+		g++ \
 		gcc \
 		krb5-dev \
 		libc-dev \
@@ -51,7 +57,6 @@ RUN set -eux; \
 		libxml2-dev \
 		libxslt-dev \
 		linux-headers \
-		llvm-dev clang g++ \
 		make \
 		openldap-dev \
 		openssl-dev \
@@ -76,6 +81,12 @@ RUN set -eux; \
 # explicitly update autoconf config.guess and config.sub so they support more arches/libcs
 	wget -O config/config.guess 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess?id=7d3d27baf8107b630586c962c057e22149653deb'; \
 	wget -O config/config.sub 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub?id=7d3d27baf8107b630586c962c057e22149653deb'; \
+	\
+# https://git.alpinelinux.org/aports/tree/community/postgresql12/APKBUILD?h=3.18-stable&id=a470294e6d6ca7059e41c54769b7c3c26ec901d4#n158
+	export LLVM_CONFIG="/usr/lib/llvm15/bin/llvm-config"; \
+# https://git.alpinelinux.org/aports/tree/community/postgresql12/APKBUILD?h=3.18-stable&id=a470294e6d6ca7059e41c54769b7c3c26ec901d4#n163
+	export CLANG=clang-15; \
+	\
 # configure options taken from:
 # https://anonscm.debian.org/cgit/pkg-postgresql/postgresql.git/tree/debian/rules?h=9.5
 	./configure \

--- a/14/alpine/Dockerfile
+++ b/14/alpine/Dockerfile
@@ -26,6 +26,10 @@ ENV PG_MAJOR 14
 ENV PG_VERSION 14.8
 ENV PG_SHA256 39d38f0030737ed03835debeefee3b37d335462ce4995e2497bc38d621ebe45a
 
+ENV DOCKER_PG_LLVM_DEPS \
+		llvm15-dev \
+		clang15
+
 RUN set -eux; \
 	\
 	wget -O postgresql.tar.bz2 "https://ftp.postgresql.org/pub/source/v$PG_VERSION/postgresql-$PG_VERSION.tar.bz2"; \
@@ -40,10 +44,12 @@ RUN set -eux; \
 	rm postgresql.tar.bz2; \
 	\
 	apk add --no-cache --virtual .build-deps \
+		$DOCKER_PG_LLVM_DEPS \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
 		flex \
+		g++ \
 		gcc \
 		krb5-dev \
 		libc-dev \
@@ -51,7 +57,6 @@ RUN set -eux; \
 		libxml2-dev \
 		libxslt-dev \
 		linux-headers \
-		llvm-dev clang g++ \
 		make \
 		openldap-dev \
 		openssl-dev \
@@ -78,6 +83,12 @@ RUN set -eux; \
 # explicitly update autoconf config.guess and config.sub so they support more arches/libcs
 	wget -O config/config.guess 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess?id=7d3d27baf8107b630586c962c057e22149653deb'; \
 	wget -O config/config.sub 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub?id=7d3d27baf8107b630586c962c057e22149653deb'; \
+	\
+# https://git.alpinelinux.org/aports/tree/community/postgresql12/APKBUILD?h=3.18-stable&id=a470294e6d6ca7059e41c54769b7c3c26ec901d4#n158
+	export LLVM_CONFIG="/usr/lib/llvm15/bin/llvm-config"; \
+# https://git.alpinelinux.org/aports/tree/community/postgresql12/APKBUILD?h=3.18-stable&id=a470294e6d6ca7059e41c54769b7c3c26ec901d4#n163
+	export CLANG=clang-15; \
+	\
 # configure options taken from:
 # https://anonscm.debian.org/cgit/pkg-postgresql/postgresql.git/tree/debian/rules?h=9.5
 	./configure \

--- a/15/alpine/Dockerfile
+++ b/15/alpine/Dockerfile
@@ -26,6 +26,10 @@ ENV PG_MAJOR 15
 ENV PG_VERSION 15.3
 ENV PG_SHA256 ffc7d4891f00ffbf5c3f4eab7fbbced8460b8c0ee63c5a5167133b9e6599d932
 
+ENV DOCKER_PG_LLVM_DEPS \
+		llvm15-dev \
+		clang15
+
 RUN set -eux; \
 	\
 	wget -O postgresql.tar.bz2 "https://ftp.postgresql.org/pub/source/v$PG_VERSION/postgresql-$PG_VERSION.tar.bz2"; \
@@ -40,10 +44,12 @@ RUN set -eux; \
 	rm postgresql.tar.bz2; \
 	\
 	apk add --no-cache --virtual .build-deps \
+		$DOCKER_PG_LLVM_DEPS \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
 		flex \
+		g++ \
 		gcc \
 		krb5-dev \
 		libc-dev \
@@ -51,7 +57,6 @@ RUN set -eux; \
 		libxml2-dev \
 		libxslt-dev \
 		linux-headers \
-		llvm-dev clang g++ \
 		make \
 		openldap-dev \
 		openssl-dev \
@@ -80,6 +85,12 @@ RUN set -eux; \
 # explicitly update autoconf config.guess and config.sub so they support more arches/libcs
 	wget -O config/config.guess 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess?id=7d3d27baf8107b630586c962c057e22149653deb'; \
 	wget -O config/config.sub 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub?id=7d3d27baf8107b630586c962c057e22149653deb'; \
+	\
+# https://git.alpinelinux.org/aports/tree/community/postgresql12/APKBUILD?h=3.18-stable&id=a470294e6d6ca7059e41c54769b7c3c26ec901d4#n158
+	export LLVM_CONFIG="/usr/lib/llvm15/bin/llvm-config"; \
+# https://git.alpinelinux.org/aports/tree/community/postgresql12/APKBUILD?h=3.18-stable&id=a470294e6d6ca7059e41c54769b7c3c26ec901d4#n163
+	export CLANG=clang-15; \
+	\
 # configure options taken from:
 # https://anonscm.debian.org/cgit/pkg-postgresql/postgresql.git/tree/debian/rules?h=9.5
 	./configure \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -20,6 +20,11 @@ ENV PG_MAJOR {{ env.version }}
 ENV PG_VERSION {{ .version }}
 ENV PG_SHA256 {{ .sha256 }}
 
+{{ def llvmver: "15" -}}
+ENV DOCKER_PG_LLVM_DEPS \
+		llvm{{ llvmver }}-dev \
+		clang{{ llvmver }}
+
 RUN set -eux; \
 	\
 	wget -O postgresql.tar.bz2 "https://ftp.postgresql.org/pub/source/v$PG_VERSION/postgresql-$PG_VERSION.tar.bz2"; \
@@ -34,10 +39,12 @@ RUN set -eux; \
 	rm postgresql.tar.bz2; \
 	\
 	apk add --no-cache --virtual .build-deps \
+		$DOCKER_PG_LLVM_DEPS \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
 		flex \
+		g++ \
 		gcc \
 		krb5-dev \
 		libc-dev \
@@ -45,9 +52,6 @@ RUN set -eux; \
 		libxml2-dev \
 		libxslt-dev \
 		linux-headers \
-{{ if .major >= 11 then ( -}}
-		llvm-dev clang g++ \
-{{ ) else "" end -}}
 		make \
 		openldap-dev \
 		openssl-dev \
@@ -80,6 +84,12 @@ RUN set -eux; \
 # explicitly update autoconf config.guess and config.sub so they support more arches/libcs
 	wget -O config/config.guess 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess?id=7d3d27baf8107b630586c962c057e22149653deb'; \
 	wget -O config/config.sub 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub?id=7d3d27baf8107b630586c962c057e22149653deb'; \
+	\
+# https://git.alpinelinux.org/aports/tree/community/postgresql12/APKBUILD?h=3.18-stable&id=a470294e6d6ca7059e41c54769b7c3c26ec901d4#n158
+	export LLVM_CONFIG="/usr/lib/llvm{{ llvmver }}/bin/llvm-config"; \
+# https://git.alpinelinux.org/aports/tree/community/postgresql12/APKBUILD?h=3.18-stable&id=a470294e6d6ca7059e41c54769b7c3c26ec901d4#n163
+	export CLANG=clang-{{ llvmver }}; \
+	\
 # configure options taken from:
 # https://anonscm.debian.org/cgit/pkg-postgresql/postgresql.git/tree/debian/rules?h=9.5
 	./configure \
@@ -110,9 +120,7 @@ RUN set -eux; \
 		--with-libxml \
 		--with-libxslt \
 		--with-icu \
-{{ if .major >= 11 then ( -}}
 		--with-llvm \
-{{ ) else "" end -}}
 {{ if .major >= 14 then ( -}}
 		--with-lz4 \
 {{ ) else "" end -}}
@@ -169,9 +177,6 @@ RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$P
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-{{ if .major >= 11 then "" else ( -}}
-RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
-{{ ) end -}}
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -181,9 +181,6 @@ RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PG
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-{{ if .major >= 11 then "" else ( -}}
-RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
-{{ ) end -}}
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL


### PR DESCRIPTION
PostgreSQL doesn't support llvm 16 (https://github.com/docker-library/postgres/issues/1076#issuecomment-1545209600):
- https://www.postgresql.org/message-id/flat/17927-2d7146227560bdf3%40postgresql.org
- https://www.postgresql.org/message-id/flat/17929-71c7a59e1930980b%40postgresql.org

Thank you for your comments on #1076 pointing me in a direction for a fix ❤️. Apologies for any stress and work that this caused 🙇‍♂️. With the added test in https://github.com/docker-library/official-images/pull/14646, we shouldn't run into this issue again.

Fixes https://github.com/docker-library/postgres/issues/1076