### PR TITLE
Fix owner and group of $PGDATA at start

### DIFF
--- a/11/alpine3.17/docker-entrypoint.sh
+++ b/11/alpine3.17/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/11/alpine3.18/docker-entrypoint.sh
+++ b/11/alpine3.18/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/11/bookworm/docker-entrypoint.sh
+++ b/11/bookworm/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/11/bullseye/docker-entrypoint.sh
+++ b/11/bullseye/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/12/alpine3.17/docker-entrypoint.sh
+++ b/12/alpine3.17/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/12/alpine3.18/docker-entrypoint.sh
+++ b/12/alpine3.18/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/12/bookworm/docker-entrypoint.sh
+++ b/12/bookworm/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/12/bullseye/docker-entrypoint.sh
+++ b/12/bullseye/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/13/alpine3.17/docker-entrypoint.sh
+++ b/13/alpine3.17/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/13/alpine3.18/docker-entrypoint.sh
+++ b/13/alpine3.18/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/13/bookworm/docker-entrypoint.sh
+++ b/13/bookworm/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/13/bullseye/docker-entrypoint.sh
+++ b/13/bullseye/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/14/alpine3.17/docker-entrypoint.sh
+++ b/14/alpine3.17/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/14/alpine3.18/docker-entrypoint.sh
+++ b/14/alpine3.18/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/14/bookworm/docker-entrypoint.sh
+++ b/14/bookworm/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/14/bullseye/docker-entrypoint.sh
+++ b/14/bullseye/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/15/alpine3.17/docker-entrypoint.sh
+++ b/15/alpine3.17/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/15/alpine3.18/docker-entrypoint.sh
+++ b/15/alpine3.18/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/15/bookworm/docker-entrypoint.sh
+++ b/15/bookworm/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/15/bullseye/docker-entrypoint.sh
+++ b/15/bullseye/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/16/alpine3.17/docker-entrypoint.sh
+++ b/16/alpine3.17/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/16/alpine3.18/docker-entrypoint.sh
+++ b/16/alpine3.18/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/16/bookworm/docker-entrypoint.sh
+++ b/16/bookworm/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :

--- a/16/bullseye/docker-entrypoint.sh
+++ b/16/bullseye/docker-entrypoint.sh
@@ -39,6 +39,7 @@ docker_create_db_directories() {
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
 	chmod 00700 "$PGDATA" || :
+	chown -R postgres:postgres "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :


### PR DESCRIPTION
When mounting a volume to /var/lib/postgresql/data the owner (postgres) and group (postgres) set by the Dockerfile are "lost". Thus, if doing so, one currently needs an init container to fix that. This change avoids that.