### PR TITLE
Export `docker_process_sql` for availability in executed initdb bash

### DIFF
--- a/16/alpine3.17/docker-entrypoint.sh
+++ b/16/alpine3.17/docker-entrypoint.sh
@@ -196,6 +196,7 @@ docker_process_sql() {
 
 	PGHOST= PGHOSTADDR= "${query_runner[@]}" "$@"
 }
+export -f docker_process_sql
 
 # create initial database
 # uses environment variables for input: POSTGRES_DB

--- a/16/alpine3.18/docker-entrypoint.sh
+++ b/16/alpine3.18/docker-entrypoint.sh
@@ -196,6 +196,7 @@ docker_process_sql() {
 
 	PGHOST= PGHOSTADDR= "${query_runner[@]}" "$@"
 }
+export -f docker_process_sql
 
 # create initial database
 # uses environment variables for input: POSTGRES_DB

--- a/16/bookworm/docker-entrypoint.sh
+++ b/16/bookworm/docker-entrypoint.sh
@@ -196,6 +196,7 @@ docker_process_sql() {
 
 	PGHOST= PGHOSTADDR= "${query_runner[@]}" "$@"
 }
+export -f docker_process_sql
 
 # create initial database
 # uses environment variables for input: POSTGRES_DB

--- a/16/bullseye/docker-entrypoint.sh
+++ b/16/bullseye/docker-entrypoint.sh
@@ -196,6 +196,7 @@ docker_process_sql() {
 
 	PGHOST= PGHOSTADDR= "${query_runner[@]}" "$@"
 }
+export -f docker_process_sql
 
 # create initial database
 # uses environment variables for input: POSTGRES_DB

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -196,6 +196,7 @@ docker_process_sql() {
 
 	PGHOST= PGHOSTADDR= "${query_runner[@]}" "$@"
 }
+export -f docker_process_sql
 
 # create initial database
 # uses environment variables for input: POSTGRES_DB


### PR DESCRIPTION
This way, executed bash initdb scripts do not need to source the entrypoint script (nor hardcode its path) to be able to use the function.

Note that the export only works for executed _bash_ scripts.

Not crucial by any means, but I think it'd be nice to have.

Could apply to < 16 entrypoints too, if this is seen desirable.