### PR TITLE
Move latest to 16

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,7 +2,7 @@
 set -Eeuo pipefail
 
 declare -A aliases=(
-	[15]='latest'
+	[16]='latest'
 )
 
 self="$(basename "$BASH_SOURCE")"


### PR DESCRIPTION
> September 14, 2023 - The PostgreSQL Global Development Group today announced the release of PostgreSQL 16
>
>\- https://www.postgresql.org/about/news/postgresql-16-released-2715/

```diff
$ diff -u ../official-images/library/postgres <(./generate-stackbrew-library.sh)
--- ../official-images/library/postgres 2023-09-01 13:26:17.532182117 -0700
+++ /dev/fd/63  2023-09-14 14:35:27.532811966 -0700
@@ -1,45 +1,45 @@
-# this file is generated via https://github.com/docker-library/postgres/blob/5ea98fe00be95fbbe642732d62af3b4dbc83f442/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/postgres/blob/7df6bc166fbf0d7f28c85700235012317a22f88e/generate-stackbrew-library.sh

 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git

-Tags: 16rc1, 16rc1-bookworm
+Tags: 16.0, 16, latest, 16.0-bookworm, 16-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2f0ed0c7e8f8b05b294740f150397eec0af8dc50
+GitCommit: 7442464585e3cd75554976cbe94819a42da10bbd
 Directory: 16/bookworm

-Tags: 16rc1-bullseye
+Tags: 16.0-bullseye, 16-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2f0ed0c7e8f8b05b294740f150397eec0af8dc50
+GitCommit: 7442464585e3cd75554976cbe94819a42da10bbd
 Directory: 16/bullseye

-Tags: 16rc1-alpine3.18, 16rc1-alpine
+Tags: 16.0-alpine3.18, 16-alpine3.18, alpine3.18, 16.0-alpine, 16-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f0ed0c7e8f8b05b294740f150397eec0af8dc50
+GitCommit: 7442464585e3cd75554976cbe94819a42da10bbd
 Directory: 16/alpine3.18

-Tags: 16rc1-alpine3.17
+Tags: 16.0-alpine3.17, 16-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f0ed0c7e8f8b05b294740f150397eec0af8dc50
+GitCommit: 7442464585e3cd75554976cbe94819a42da10bbd
 Directory: 16/alpine3.17

-Tags: 15.4, 15, latest, 15.4-bookworm, 15-bookworm, bookworm
+Tags: 15.4, 15, 15.4-bookworm, 15-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1a73ab671b5f0f18313726e734c76bf171385c32
+GitCommit: 8a631b939a0b4197cb6bef49b50b6c40c80ddf5b
 Directory: 15/bookworm

-Tags: 15.4-bullseye, 15-bullseye, bullseye
+Tags: 15.4-bullseye, 15-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1a73ab671b5f0f18313726e734c76bf171385c32
+GitCommit: 8a631b939a0b4197cb6bef49b50b6c40c80ddf5b
 Directory: 15/bullseye

-Tags: 15.4-alpine3.18, 15-alpine3.18, alpine3.18, 15.4-alpine, 15-alpine, alpine
+Tags: 15.4-alpine3.18, 15-alpine3.18, 15.4-alpine, 15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1a73ab671b5f0f18313726e734c76bf171385c32
 Directory: 15/alpine3.18

-Tags: 15.4-alpine3.17, 15-alpine3.17, alpine3.17
+Tags: 15.4-alpine3.17, 15-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1a73ab671b5f0f18313726e734c76bf171385c32
 Directory: 15/alpine3.17
```