### PR TITLE
Added bullseye as the default debian version for version 11

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -19,7 +19,7 @@
       ],
       "version": "11.21-1.pgdg110+1"
     },
-    "debian": "",
+    "debian": "bullseye",
     "major": 11,
     "sha256": "07b0837471d5dd77b25166b34718f3ba10816b6ad61e691e6fc547cf3fcff850",
     "variants": [


### PR DESCRIPTION
The default was removed altogether when stretch reached EOL. Using bullseye instead of bookworm to avoid to big of a jump.