### PR TITLE
Added ability to use image as an init container

### DIFF
--- a/11/alpine3.17/docker-entrypoint.sh
+++ b/11/alpine3.17/docker-entrypoint.sh
@@ -299,13 +299,22 @@ _main() {
 		set -- postgres "$@"
 	fi
 
-	if [ "$1" = 'postgres' ] && ! _pg_want_help "$@"; then
+	init=false
+	if [ "$1" = 'init' ]; then
+		init=true
+	fi
+
+	if $init || ( [ "$1" = 'postgres' ] && ! _pg_want_help "$@" ); then
 		docker_setup_env
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
 			# then restart script as postgres user
 			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		if [ "$1" = 'init' ]; then
+			shift
 		fi
 
 		# only run initialization on an empty data directory
@@ -343,7 +352,9 @@ _main() {
 		fi
 	fi
 
-	exec "$@"
+	if ! $init; then
+		exec "$@"
+	fi
 }
 
 if ! _is_sourced; then

--- a/11/alpine3.18/docker-entrypoint.sh
+++ b/11/alpine3.18/docker-entrypoint.sh
@@ -299,13 +299,22 @@ _main() {
 		set -- postgres "$@"
 	fi
 
-	if [ "$1" = 'postgres' ] && ! _pg_want_help "$@"; then
+	init=false
+	if [ "$1" = 'init' ]; then
+		init=true
+	fi
+
+	if $init || ( [ "$1" = 'postgres' ] && ! _pg_want_help "$@" ); then
 		docker_setup_env
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
 			# then restart script as postgres user
 			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		if [ "$1" = 'init' ]; then
+			shift
 		fi
 
 		# only run initialization on an empty data directory
@@ -343,7 +352,9 @@ _main() {
 		fi
 	fi
 
-	exec "$@"
+	if ! $init; then
+		exec "$@"
+	fi
 }
 
 if ! _is_sourced; then

--- a/12/alpine3.17/docker-entrypoint.sh
+++ b/12/alpine3.17/docker-entrypoint.sh
@@ -299,13 +299,22 @@ _main() {
 		set -- postgres "$@"
 	fi
 
-	if [ "$1" = 'postgres' ] && ! _pg_want_help "$@"; then
+	init=false
+	if [ "$1" = 'init' ]; then
+		init=true
+	fi
+
+	if $init || ( [ "$1" = 'postgres' ] && ! _pg_want_help "$@" ); then
 		docker_setup_env
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
 			# then restart script as postgres user
 			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		if [ "$1" = 'init' ]; then
+			shift
 		fi
 
 		# only run initialization on an empty data directory
@@ -343,7 +352,9 @@ _main() {
 		fi
 	fi
 
-	exec "$@"
+	if ! $init; then
+		exec "$@"
+	fi
 }
 
 if ! _is_sourced; then

--- a/12/alpine3.18/docker-entrypoint.sh
+++ b/12/alpine3.18/docker-entrypoint.sh
@@ -299,13 +299,22 @@ _main() {
 		set -- postgres "$@"
 	fi
 
-	if [ "$1" = 'postgres' ] && ! _pg_want_help "$@"; then
+	init=false
+	if [ "$1" = 'init' ]; then
+		init=true
+	fi
+
+	if $init || ( [ "$1" = 'postgres' ] && ! _pg_want_help "$@" ); then
 		docker_setup_env
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
 			# then restart script as postgres user
 			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		if [ "$1" = 'init' ]; then
+			shift
 		fi
 
 		# only run initialization on an empty data directory
@@ -343,7 +352,9 @@ _main() {
 		fi
 	fi
 
-	exec "$@"
+	if ! $init; then
+		exec "$@"
+	fi
 }
 
 if ! _is_sourced; then

--- a/13/alpine3.17/docker-entrypoint.sh
+++ b/13/alpine3.17/docker-entrypoint.sh
@@ -299,13 +299,22 @@ _main() {
 		set -- postgres "$@"
 	fi
 
-	if [ "$1" = 'postgres' ] && ! _pg_want_help "$@"; then
+	init=false
+	if [ "$1" = 'init' ]; then
+		init=true
+	fi
+
+	if $init || ( [ "$1" = 'postgres' ] && ! _pg_want_help "$@" ); then
 		docker_setup_env
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
 			# then restart script as postgres user
 			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		if [ "$1" = 'init' ]; then
+			shift
 		fi
 
 		# only run initialization on an empty data directory
@@ -343,7 +352,9 @@ _main() {
 		fi
 	fi
 
-	exec "$@"
+	if ! $init; then
+		exec "$@"
+	fi
 }
 
 if ! _is_sourced; then

--- a/13/alpine3.18/docker-entrypoint.sh
+++ b/13/alpine3.18/docker-entrypoint.sh
@@ -299,13 +299,22 @@ _main() {
 		set -- postgres "$@"
 	fi
 
-	if [ "$1" = 'postgres' ] && ! _pg_want_help "$@"; then
+	init=false
+	if [ "$1" = 'init' ]; then
+		init=true
+	fi
+
+	if $init || ( [ "$1" = 'postgres' ] && ! _pg_want_help "$@" ); then
 		docker_setup_env
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
 			# then restart script as postgres user
 			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		if [ "$1" = 'init' ]; then
+			shift
 		fi
 
 		# only run initialization on an empty data directory
@@ -343,7 +352,9 @@ _main() {
 		fi
 	fi
 
-	exec "$@"
+	if ! $init; then
+		exec "$@"
+	fi
 }
 
 if ! _is_sourced; then

--- a/14/alpine3.17/docker-entrypoint.sh
+++ b/14/alpine3.17/docker-entrypoint.sh
@@ -299,13 +299,22 @@ _main() {
 		set -- postgres "$@"
 	fi
 
-	if [ "$1" = 'postgres' ] && ! _pg_want_help "$@"; then
+	init=false
+	if [ "$1" = 'init' ]; then
+		init=true
+	fi
+
+	if $init || ( [ "$1" = 'postgres' ] && ! _pg_want_help "$@" ); then
 		docker_setup_env
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
 			# then restart script as postgres user
 			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		if [ "$1" = 'init' ]; then
+			shift
 		fi
 
 		# only run initialization on an empty data directory
@@ -343,7 +352,9 @@ _main() {
 		fi
 	fi
 
-	exec "$@"
+	if ! $init; then
+		exec "$@"
+	fi
 }
 
 if ! _is_sourced; then

--- a/14/alpine3.18/docker-entrypoint.sh
+++ b/14/alpine3.18/docker-entrypoint.sh
@@ -299,13 +299,22 @@ _main() {
 		set -- postgres "$@"
 	fi
 
-	if [ "$1" = 'postgres' ] && ! _pg_want_help "$@"; then
+	init=false
+	if [ "$1" = 'init' ]; then
+		init=true
+	fi
+
+	if $init || ( [ "$1" = 'postgres' ] && ! _pg_want_help "$@" ); then
 		docker_setup_env
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
 			# then restart script as postgres user
 			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		if [ "$1" = 'init' ]; then
+			shift
 		fi
 
 		# only run initialization on an empty data directory
@@ -343,7 +352,9 @@ _main() {
 		fi
 	fi
 
-	exec "$@"
+	if ! $init; then
+		exec "$@"
+	fi
 }
 
 if ! _is_sourced; then

--- a/15/alpine3.17/docker-entrypoint.sh
+++ b/15/alpine3.17/docker-entrypoint.sh
@@ -299,13 +299,22 @@ _main() {
 		set -- postgres "$@"
 	fi
 
-	if [ "$1" = 'postgres' ] && ! _pg_want_help "$@"; then
+	init=false
+	if [ "$1" = 'init' ]; then
+		init=true
+	fi
+
+	if $init || ( [ "$1" = 'postgres' ] && ! _pg_want_help "$@" ); then
 		docker_setup_env
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
 			# then restart script as postgres user
 			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		if [ "$1" = 'init' ]; then
+			shift
 		fi
 
 		# only run initialization on an empty data directory
@@ -343,7 +352,9 @@ _main() {
 		fi
 	fi
 
-	exec "$@"
+	if ! $init; then
+		exec "$@"
+	fi
 }
 
 if ! _is_sourced; then

--- a/15/alpine3.18/docker-entrypoint.sh
+++ b/15/alpine3.18/docker-entrypoint.sh
@@ -299,13 +299,22 @@ _main() {
 		set -- postgres "$@"
 	fi
 
-	if [ "$1" = 'postgres' ] && ! _pg_want_help "$@"; then
+	init=false
+	if [ "$1" = 'init' ]; then
+		init=true
+	fi
+
+	if $init || ( [ "$1" = 'postgres' ] && ! _pg_want_help "$@" ); then
 		docker_setup_env
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
 			# then restart script as postgres user
 			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		if [ "$1" = 'init' ]; then
+			shift
 		fi
 
 		# only run initialization on an empty data directory
@@ -343,7 +352,9 @@ _main() {
 		fi
 	fi
 
-	exec "$@"
+	if ! $init; then
+		exec "$@"
+	fi
 }
 
 if ! _is_sourced; then

--- a/16/alpine3.17/docker-entrypoint.sh
+++ b/16/alpine3.17/docker-entrypoint.sh
@@ -299,13 +299,22 @@ _main() {
 		set -- postgres "$@"
 	fi
 
-	if [ "$1" = 'postgres' ] && ! _pg_want_help "$@"; then
+	init=false
+	if [ "$1" = 'init' ]; then
+		init=true
+	fi
+
+	if $init || ( [ "$1" = 'postgres' ] && ! _pg_want_help "$@" ); then
 		docker_setup_env
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
 			# then restart script as postgres user
 			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		if [ "$1" = 'init' ]; then
+			shift
 		fi
 
 		# only run initialization on an empty data directory
@@ -343,7 +352,9 @@ _main() {
 		fi
 	fi
 
-	exec "$@"
+	if ! $init; then
+		exec "$@"
+	fi
 }
 
 if ! _is_sourced; then

--- a/16/alpine3.18/docker-entrypoint.sh
+++ b/16/alpine3.18/docker-entrypoint.sh
@@ -299,13 +299,22 @@ _main() {
 		set -- postgres "$@"
 	fi
 
-	if [ "$1" = 'postgres' ] && ! _pg_want_help "$@"; then
+	init=false
+	if [ "$1" = 'init' ]; then
+		init=true
+	fi
+
+	if $init || ( [ "$1" = 'postgres' ] && ! _pg_want_help "$@" ); then
 		docker_setup_env
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
 			# then restart script as postgres user
 			exec su-exec postgres "$BASH_SOURCE" "$@"
+		fi
+
+		if [ "$1" = 'init' ]; then
+			shift
 		fi
 
 		# only run initialization on an empty data directory
@@ -343,7 +352,9 @@ _main() {
 		fi
 	fi
 
-	exec "$@"
+	if ! $init; then
+		exec "$@"
+	fi
 }
 
 if ! _is_sourced; then


### PR DESCRIPTION
Example:

```yaml
services:
  db-init:
    build:
      context: ../alpine3.18
    image: postgres:16-alpine
    environment:
      POSTGRES_PASSWORD: example
    volumes:
      - pgdata:/var/lib/postgresql/data/
    user: postgres
    command: init
```

Output:

```
Attaching to db-1, db-init-1
db-init-1  | The files belonging to this database system will be owned by user "postgres".
db-init-1  | This user must also own the server process.
db-init-1  | 
db-init-1  | The database cluster will be initialized with locale "en_US.utf8".
db-init-1  | The default database encoding has accordingly been set to "UTF8".
db-init-1  | The default text search configuration will be set to "english".
db-init-1  | 
db-init-1  | Data page checksums are disabled.
db-init-1  | 
db-init-1  | fixing permissions on existing directory /var/lib/postgresql/data ... ok
db-init-1  | creating subdirectories ... ok
db-init-1  | selecting dynamic shared memory implementation ... posix
db-init-1  | selecting default max_connections ... 100
db-init-1  | selecting default shared_buffers ... 128MB
db-init-1  | selecting default time zone ... UTC
db-init-1  | creating configuration files ... ok
db-init-1  | running bootstrap script ... ok
db-init-1  | sh: locale: not found
db-init-1  | 2023-11-07 17:14:26.730 UTC [21] WARNING:  no usable system locales were found
db-init-1  | performing post-bootstrap initialization ... ok
db-init-1  | initdb: warning: enabling "trust" authentication for local connections
db-init-1  | initdb: hint: You can change this by editing pg_hba.conf or using the option -A, or --auth-local and --auth-host, the next time you run initdb.
db-init-1  | syncing data to disk ... ok
db-init-1  | 
db-init-1  | 
db-init-1  | Success. You can now start the database server using:
db-init-1  | 
db-init-1  |     pg_ctl -D /var/lib/postgresql/data -l logfile start
db-init-1  | 
db-init-1  | waiting for server to start....2023-11-07 17:14:27.142 UTC [27] LOG:  starting PostgreSQL 16.0 on aarch64-unknown-linux-musl, compiled by gcc (Alpine 12.2.1_git20220924-r10) 12.2.1 20220924, 64-bit
db-init-1  | 2023-11-07 17:14:27.143 UTC [27] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
db-init-1  | 2023-11-07 17:14:27.147 UTC [30] LOG:  database system was shut down at 2023-11-07 17:14:26 UTC
db-init-1  | 2023-11-07 17:14:27.150 UTC [27] LOG:  database system is ready to accept connections
db-init-1  |  done
db-init-1  | server started
db-init-1  | 
db-init-1  | /usr/local/bin/docker-entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
db-init-1  | 
db-init-1  | waiting for server to shut down....2023-11-07 17:14:27.240 UTC [27] LOG:  received fast shutdown request
db-init-1  | 2023-11-07 17:14:27.241 UTC [27] LOG:  aborting any active transactions
db-init-1  | 2023-11-07 17:14:27.242 UTC [27] LOG:  background worker "logical replication launcher" (PID 33) exited with exit code 1
db-init-1  | 2023-11-07 17:14:27.244 UTC [28] LOG:  shutting down
db-init-1  | 2023-11-07 17:14:27.245 UTC [28] LOG:  checkpoint starting: shutdown immediate
db-init-1  | 2023-11-07 17:14:27.255 UTC [28] LOG:  checkpoint complete: wrote 3 buffers (0.0%); 0 WAL file(s) added, 0 removed, 0 recycled; write=0.005 s, sync=0.001 s, total=0.012 s; sync files=2, longest=0.001 s, average=0.001 s; distance=0 kB, estimate=0 kB; lsn=0/14EA400, redo lsn=0/14EA400
db-init-1  | 2023-11-07 17:14:27.257 UTC [27] LOG:  database system is shut down
db-init-1  |  done
db-init-1  | server stopped
db-init-1  | 
db-init-1  | PostgreSQL init process complete; ready for start up.
db-init-1  | 
db-init-1 exited with code 0
```