### PR TITLE
add Healthcheck

### DIFF
--- a/16/bullseye/Dockerfile
+++ b/16/bullseye/Dockerfile
@@ -215,5 +215,8 @@ STOPSIGNAL SIGINT
 # documentation at https://www.postgresql.org/docs/12/server-start.html notes
 # that even 90 seconds may not be long enough in many instances.
 
+HEALTHCHECK --interval=1s --timeout=1s --retries=60 \
+	CMD test -f /dev/shm/ready
+
 EXPOSE 5432
 CMD ["postgres"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -343,7 +343,11 @@ _main() {
 		fi
 	fi
 
+	touch /dev/shm/ready
+
 	exec "$@"
+
+	rm /dev/shm/ready
 }
 
 if ! _is_sourced; then


### PR DESCRIPTION
This allows to check for the health of the postgres container. This is usefull for docker-compose. 
Services might use:
```yaml
depends_on:
  mypostgres-container:
    condition: service_healthy
```
to check for a up and running postgres instance

normaly i would check for the open tcp port, but postgres starts the temporary server to setup the db. Those might cause a simple port check (like `grep -q ":1538" /proc/net/tcp` ) to report a false positive.
This might also not be a guarante, that the server is available. Maybe it would be a good idea to check for the shm and the port like this:
```Dockerfile
HEALTHCHECK --interval=1s --timeout=1s --retries=60 \
	CMD-SHELL test -f /dev/shm/ready && grep -q :1538 /proc/net/tcp
```

Let me know what you think.
Just a simple "process is running" check, or an advanced "process is running and post is open" check or an even more advanced "process is running and a SELECT 1; query works"

I just implemented it for one `Dockerfile` now. If you are fine with this, i would add this to every `Dockerfile`.