### PR TITLE
Add new "docker-ensure-initdb.sh" script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
-/*/**/Dockerfile            linguist-generated
-/*/**/docker-entrypoint.sh  linguist-generated
-/Dockerfile*.template       linguist-language=Dockerfile
+/*/**/Dockerfile               linguist-generated
+/*/**/docker-ensure-initdb.sh  linguist-generated
+/*/**/docker-entrypoint.sh     linguist-generated
+/Dockerfile*.template          linguist-language=Dockerfile

--- a/12/alpine3.18/Dockerfile
+++ b/12/alpine3.18/Dockerfile
@@ -169,7 +169,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/12/alpine3.18/docker-ensure-initdb.sh
+++ b/12/alpine3.18/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec su-exec postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/12/alpine3.18/docker-entrypoint.sh
+++ b/12/alpine3.18/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/12/alpine3.19/Dockerfile
+++ b/12/alpine3.19/Dockerfile
@@ -169,7 +169,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/12/alpine3.19/docker-ensure-initdb.sh
+++ b/12/alpine3.19/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec su-exec postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/12/alpine3.19/docker-entrypoint.sh
+++ b/12/alpine3.19/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/12/bookworm/Dockerfile
+++ b/12/bookworm/Dockerfile
@@ -184,7 +184,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/12/bookworm/docker-ensure-initdb.sh
+++ b/12/bookworm/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec gosu postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/12/bookworm/docker-entrypoint.sh
+++ b/12/bookworm/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/12/bullseye/Dockerfile
+++ b/12/bullseye/Dockerfile
@@ -184,7 +184,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/12/bullseye/docker-ensure-initdb.sh
+++ b/12/bullseye/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec gosu postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/12/bullseye/docker-entrypoint.sh
+++ b/12/bullseye/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/13/alpine3.18/Dockerfile
+++ b/13/alpine3.18/Dockerfile
@@ -169,7 +169,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/13/alpine3.18/docker-ensure-initdb.sh
+++ b/13/alpine3.18/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec su-exec postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/13/alpine3.18/docker-entrypoint.sh
+++ b/13/alpine3.18/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/13/alpine3.19/Dockerfile
+++ b/13/alpine3.19/Dockerfile
@@ -169,7 +169,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/13/alpine3.19/docker-ensure-initdb.sh
+++ b/13/alpine3.19/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec su-exec postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/13/alpine3.19/docker-entrypoint.sh
+++ b/13/alpine3.19/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/13/bookworm/Dockerfile
+++ b/13/bookworm/Dockerfile
@@ -186,7 +186,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/13/bookworm/docker-ensure-initdb.sh
+++ b/13/bookworm/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec gosu postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/13/bookworm/docker-entrypoint.sh
+++ b/13/bookworm/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/13/bullseye/Dockerfile
+++ b/13/bullseye/Dockerfile
@@ -186,7 +186,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/13/bullseye/docker-ensure-initdb.sh
+++ b/13/bullseye/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec gosu postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/13/bullseye/docker-entrypoint.sh
+++ b/13/bullseye/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/14/alpine3.18/Dockerfile
+++ b/14/alpine3.18/Dockerfile
@@ -172,7 +172,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/14/alpine3.18/docker-ensure-initdb.sh
+++ b/14/alpine3.18/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec su-exec postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/14/alpine3.18/docker-entrypoint.sh
+++ b/14/alpine3.18/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/14/alpine3.19/Dockerfile
+++ b/14/alpine3.19/Dockerfile
@@ -172,7 +172,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/14/alpine3.19/docker-ensure-initdb.sh
+++ b/14/alpine3.19/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec su-exec postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/14/alpine3.19/docker-entrypoint.sh
+++ b/14/alpine3.19/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/14/bookworm/Dockerfile
+++ b/14/bookworm/Dockerfile
@@ -184,7 +184,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/14/bookworm/docker-ensure-initdb.sh
+++ b/14/bookworm/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec gosu postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/14/bookworm/docker-entrypoint.sh
+++ b/14/bookworm/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/14/bullseye/Dockerfile
+++ b/14/bullseye/Dockerfile
@@ -184,7 +184,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/14/bullseye/docker-ensure-initdb.sh
+++ b/14/bullseye/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec gosu postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/14/bullseye/docker-entrypoint.sh
+++ b/14/bullseye/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/15/alpine3.18/Dockerfile
+++ b/15/alpine3.18/Dockerfile
@@ -175,7 +175,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/15/alpine3.18/docker-ensure-initdb.sh
+++ b/15/alpine3.18/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec su-exec postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/15/alpine3.18/docker-entrypoint.sh
+++ b/15/alpine3.18/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/15/alpine3.19/Dockerfile
+++ b/15/alpine3.19/Dockerfile
@@ -175,7 +175,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/15/alpine3.19/docker-ensure-initdb.sh
+++ b/15/alpine3.19/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec su-exec postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/15/alpine3.19/docker-entrypoint.sh
+++ b/15/alpine3.19/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/15/bookworm/Dockerfile
+++ b/15/bookworm/Dockerfile
@@ -184,7 +184,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/15/bookworm/docker-ensure-initdb.sh
+++ b/15/bookworm/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec gosu postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/15/bookworm/docker-entrypoint.sh
+++ b/15/bookworm/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/15/bullseye/Dockerfile
+++ b/15/bullseye/Dockerfile
@@ -184,7 +184,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/15/bullseye/docker-ensure-initdb.sh
+++ b/15/bullseye/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec gosu postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/15/bullseye/docker-entrypoint.sh
+++ b/15/bullseye/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/16/alpine3.18/Dockerfile
+++ b/16/alpine3.18/Dockerfile
@@ -174,7 +174,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/16/alpine3.18/docker-ensure-initdb.sh
+++ b/16/alpine3.18/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec su-exec postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/16/alpine3.18/docker-entrypoint.sh
+++ b/16/alpine3.18/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/16/alpine3.19/Dockerfile
+++ b/16/alpine3.19/Dockerfile
@@ -174,7 +174,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/16/alpine3.19/docker-ensure-initdb.sh
+++ b/16/alpine3.19/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec su-exec postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/16/alpine3.19/docker-entrypoint.sh
+++ b/16/alpine3.19/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/16/bookworm/Dockerfile
+++ b/16/bookworm/Dockerfile
@@ -184,7 +184,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/16/bookworm/docker-ensure-initdb.sh
+++ b/16/bookworm/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec gosu postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/16/bookworm/docker-entrypoint.sh
+++ b/16/bookworm/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/16/bullseye/Dockerfile
+++ b/16/bullseye/Dockerfile
@@ -184,7 +184,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/16/bullseye/docker-ensure-initdb.sh
+++ b/16/bullseye/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec gosu postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/16/bullseye/docker-entrypoint.sh
+++ b/16/bullseye/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -194,7 +194,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -182,7 +182,8 @@ ENV PGDATA /var/lib/postgresql/data
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 1777 "$PGDATA"
 VOLUME /var/lib/postgresql/data
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint.sh docker-ensure-initdb.sh /usr/local/bin/
+RUN ln -sT docker-ensure-initdb.sh /usr/local/bin/docker-enforce-initdb.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -52,12 +52,12 @@ for version; do
 
 		echo "processing $dir ..."
 
-		cp -a docker-entrypoint.sh "$dir/"
+		cp -a docker-entrypoint.sh docker-ensure-initdb.sh "$dir/"
 
 		case "$variant" in
 			alpine*)
 				template='Dockerfile-alpine.template'
-				sed -i -e 's/gosu/su-exec/g' "$dir/docker-entrypoint.sh"
+				sed -i -e 's/gosu/su-exec/g' "$dir/docker-entrypoint.sh" "$dir/docker-ensure-initdb.sh"
 				;;
 			*)
 				template='Dockerfile-debian.template'

--- a/docker-ensure-initdb.sh
+++ b/docker-ensure-initdb.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+#
+# This script is intended for three main use cases:
+#
+#  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior
+#
+#  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution
+#       (no-op if database is already initialized)
+#
+#  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use
+#       (error if database is already initialized)
+#
+
+source /usr/local/bin/docker-entrypoint.sh
+
+# arguments to this script are assumed to be arguments to the "postgres" server (same as "docker-entrypoint.sh"), and most "docker-entrypoint.sh" functions assume "postgres" is the first argument (see "_main" over there)
+if [ "$#" -eq 0 ] || [ "$1" != 'postgres' ]; then
+	set -- postgres "$@"
+fi
+
+# see also "_main" in "docker-entrypoint.sh"
+
+docker_setup_env
+# setup data directories and permissions (when run as root)
+docker_create_db_directories
+if [ "$(id -u)" = '0' ]; then
+	# then restart script as postgres user
+	exec gosu postgres "$BASH_SOURCE" "$@"
+fi
+
+# only run initialization on an empty data directory
+if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+	docker_verify_minimum_env
+
+	# check dir permissions to reduce likelihood of half-initialized database
+	ls /docker-entrypoint-initdb.d/ > /dev/null
+
+	docker_init_database_dir
+	pg_setup_hba_conf "$@"
+
+	# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+	# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+	export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+	docker_temp_server_start "$@"
+
+	docker_setup_db
+	docker_process_init_files /docker-entrypoint-initdb.d/*
+
+	docker_temp_server_stop
+	unset PGPASSWORD
+else
+	self="$(basename "$0")"
+	case "$self" in
+		docker-ensure-initdb.sh)
+			echo >&2 "$self: note: database already initialized in '$PGDATA'!"
+			exit 0
+			;;
+
+		docker-enforce-initdb.sh)
+			echo >&2 "$self: error: (unexpected) database found in '$PGDATA'!"
+			exit 1
+			;;
+
+		*)
+			echo >&2 "$self: error: unknown file name: $self"
+			exit 99
+			;;
+	esac
+fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -225,6 +225,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'


### PR DESCRIPTION
This mimics the behavior of `docker-entrypoint.sh` before it starts the PostgreSQL server.

It has three main goals/uses:

  1. (most importantly) as an example of how to use "docker-entrypoint.sh" to extend/reuse the initialization behavior

  2. ("docker-ensure-initdb.sh") as a Kubernetes "init container" to ensure the provided database directory is initialized; see also "startup probes" for an alternative solution (no-op if database is already initialized)

  3. ("docker-enforce-initdb.sh") as part of CI to ensure the database is fully initialized before use (error if database is already initialized)

Closes #1141 (alternative to)
Closes #1113
Closes #731

This is something I wrote more than a year ago, but wasn't sure we wanted to actually commit to maintaining over time (and I'm still not 100% sold, but it does seem useful as an example of how to use `docker-entrypoint.sh` correctly).