### PR TITLE
Debian images: Use locale-gen instead of localdef

### DIFF
--- a/11/bookworm/Dockerfile
+++ b/11/bookworm/Dockerfile
@@ -55,7 +55,8 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
+	locale-gen
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/11/bookworm/Dockerfile
+++ b/11/bookworm/Dockerfile
@@ -55,8 +55,9 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
-	locale-gen
+	echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen; \
+	locale-gen; \
+	locale -a | grep 'en_US.utf8'
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -55,7 +55,8 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
+	locale-gen
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -55,8 +55,9 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
-	locale-gen
+	echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen; \
+	locale-gen; \
+	locale -a | grep 'en_US.utf8'
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/12/bookworm/Dockerfile
+++ b/12/bookworm/Dockerfile
@@ -55,7 +55,8 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
+	locale-gen
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/12/bookworm/Dockerfile
+++ b/12/bookworm/Dockerfile
@@ -55,8 +55,9 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
-	locale-gen
+	echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen; \
+	locale-gen; \
+	locale -a | grep 'en_US.utf8'
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/12/bullseye/Dockerfile
+++ b/12/bullseye/Dockerfile
@@ -55,7 +55,8 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
+	locale-gen
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/12/bullseye/Dockerfile
+++ b/12/bullseye/Dockerfile
@@ -55,8 +55,9 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
-	locale-gen
+	echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen; \
+	locale-gen; \
+	locale -a | grep 'en_US.utf8'
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/13/bookworm/Dockerfile
+++ b/13/bookworm/Dockerfile
@@ -55,7 +55,8 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
+	locale-gen
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/13/bookworm/Dockerfile
+++ b/13/bookworm/Dockerfile
@@ -55,8 +55,9 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
-	locale-gen
+	echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen; \
+	locale-gen; \
+	locale -a | grep 'en_US.utf8'
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/13/bullseye/Dockerfile
+++ b/13/bullseye/Dockerfile
@@ -55,7 +55,8 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
+	locale-gen
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/13/bullseye/Dockerfile
+++ b/13/bullseye/Dockerfile
@@ -55,8 +55,9 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
-	locale-gen
+	echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen; \
+	locale-gen; \
+	locale -a | grep 'en_US.utf8'
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/14/bookworm/Dockerfile
+++ b/14/bookworm/Dockerfile
@@ -55,7 +55,8 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
+	locale-gen
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/14/bookworm/Dockerfile
+++ b/14/bookworm/Dockerfile
@@ -55,8 +55,9 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
-	locale-gen
+	echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen; \
+	locale-gen; \
+	locale -a | grep 'en_US.utf8'
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/14/bullseye/Dockerfile
+++ b/14/bullseye/Dockerfile
@@ -55,7 +55,8 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
+	locale-gen
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/14/bullseye/Dockerfile
+++ b/14/bullseye/Dockerfile
@@ -55,8 +55,9 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
-	locale-gen
+	echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen; \
+	locale-gen; \
+	locale -a | grep 'en_US.utf8'
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/15/bookworm/Dockerfile
+++ b/15/bookworm/Dockerfile
@@ -55,7 +55,8 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
+	locale-gen
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/15/bookworm/Dockerfile
+++ b/15/bookworm/Dockerfile
@@ -55,8 +55,9 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
-	locale-gen
+	echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen; \
+	locale-gen; \
+	locale -a | grep 'en_US.utf8'
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/15/bullseye/Dockerfile
+++ b/15/bullseye/Dockerfile
@@ -55,7 +55,8 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
+	locale-gen
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/15/bullseye/Dockerfile
+++ b/15/bullseye/Dockerfile
@@ -55,8 +55,9 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
-	locale-gen
+	echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen; \
+	locale-gen; \
+	locale -a | grep 'en_US.utf8'
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/16/bookworm/Dockerfile
+++ b/16/bookworm/Dockerfile
@@ -55,7 +55,8 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
+	locale-gen
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/16/bookworm/Dockerfile
+++ b/16/bookworm/Dockerfile
@@ -55,8 +55,9 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
-	locale-gen
+	echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen; \
+	locale-gen; \
+	locale -a | grep 'en_US.utf8'
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/16/bullseye/Dockerfile
+++ b/16/bullseye/Dockerfile
@@ -55,7 +55,8 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
+	locale-gen
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/16/bullseye/Dockerfile
+++ b/16/bullseye/Dockerfile
@@ -55,8 +55,9 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
-	locale-gen
+	echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen; \
+	locale-gen; \
+	locale -a | grep 'en_US.utf8'
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -49,8 +49,9 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
-	locale-gen
+	echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen; \
+	locale-gen; \
+	locale -a | grep 'en_US.utf8'
 ENV LANG en_US.utf8
 
 RUN set -eux; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -49,7 +49,8 @@ RUN set -eux; \
 		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
 	fi; \
 	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+	echo en_US.UTF-8 UTF-8 >> /etc/locale.gen; \
+	locale-gen
 ENV LANG en_US.utf8
 
 RUN set -eux; \


### PR DESCRIPTION
The use of manually calling localdef caused any future update to the locales package to remove the manually installed locales, since locale-gen takes precendence. This would usually be encountered when a downstream Dockerfile added additional packages, and as a side effect caused an upgrade to the locales package.

Fix by relying on the /etc/locale.gen file, which is the official place to specify which locales should be installed.

Fixes #1112