### PR TITLE
Revert "Added inline SBOM for binaries downloaded outside package manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .jq-template.awk
-template-helper-functions.jq

--- a/12/alpine3.18/Dockerfile
+++ b/12/alpine3.18/Dockerfile
@@ -4,7 +4,6 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-
 FROM alpine:3.18
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -152,8 +151,7 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"postgres-sbom","packages":[{"name":"postgres","versionInfo":"12.17","SPDXID":"SPDXRef-Package--postgres","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/postgres@12.17?os_name=alpine&os_version=3.18"}],"licenseDeclared":"PostgreSQL"}]}' > /usr/local/postgres.spdx.json \
-	; \
+	\
 	postgres --version
 
 # make the sample config easier to munge (and "correct by default")

--- a/12/alpine3.19/Dockerfile
+++ b/12/alpine3.19/Dockerfile
@@ -4,7 +4,6 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-
 FROM alpine:3.19
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -152,8 +151,7 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"postgres-sbom","packages":[{"name":"postgres","versionInfo":"12.17","SPDXID":"SPDXRef-Package--postgres","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/postgres@12.17?os_name=alpine&os_version=3.19"}],"licenseDeclared":"PostgreSQL"}]}' > /usr/local/postgres.spdx.json \
-	; \
+	\
 	postgres --version
 
 # make the sample config easier to munge (and "correct by default")

--- a/13/alpine3.18/Dockerfile
+++ b/13/alpine3.18/Dockerfile
@@ -4,7 +4,6 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-
 FROM alpine:3.18
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -152,8 +151,7 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"postgres-sbom","packages":[{"name":"postgres","versionInfo":"13.13","SPDXID":"SPDXRef-Package--postgres","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/postgres@13.13?os_name=alpine&os_version=3.18"}],"licenseDeclared":"PostgreSQL"}]}' > /usr/local/postgres.spdx.json \
-	; \
+	\
 	postgres --version
 
 # make the sample config easier to munge (and "correct by default")

--- a/13/alpine3.19/Dockerfile
+++ b/13/alpine3.19/Dockerfile
@@ -4,7 +4,6 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-
 FROM alpine:3.19
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -152,8 +151,7 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"postgres-sbom","packages":[{"name":"postgres","versionInfo":"13.13","SPDXID":"SPDXRef-Package--postgres","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/postgres@13.13?os_name=alpine&os_version=3.19"}],"licenseDeclared":"PostgreSQL"}]}' > /usr/local/postgres.spdx.json \
-	; \
+	\
 	postgres --version
 
 # make the sample config easier to munge (and "correct by default")

--- a/14/alpine3.18/Dockerfile
+++ b/14/alpine3.18/Dockerfile
@@ -4,7 +4,6 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-
 FROM alpine:3.18
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -155,8 +154,7 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"postgres-sbom","packages":[{"name":"postgres","versionInfo":"14.10","SPDXID":"SPDXRef-Package--postgres","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/postgres@14.10?os_name=alpine&os_version=3.18"}],"licenseDeclared":"PostgreSQL"}]}' > /usr/local/postgres.spdx.json \
-	; \
+	\
 	postgres --version
 
 # make the sample config easier to munge (and "correct by default")

--- a/14/alpine3.19/Dockerfile
+++ b/14/alpine3.19/Dockerfile
@@ -4,7 +4,6 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-
 FROM alpine:3.19
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -155,8 +154,7 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"postgres-sbom","packages":[{"name":"postgres","versionInfo":"14.10","SPDXID":"SPDXRef-Package--postgres","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/postgres@14.10?os_name=alpine&os_version=3.19"}],"licenseDeclared":"PostgreSQL"}]}' > /usr/local/postgres.spdx.json \
-	; \
+	\
 	postgres --version
 
 # make the sample config easier to munge (and "correct by default")

--- a/15/alpine3.18/Dockerfile
+++ b/15/alpine3.18/Dockerfile
@@ -4,7 +4,6 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-
 FROM alpine:3.18
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -158,8 +157,7 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"postgres-sbom","packages":[{"name":"postgres","versionInfo":"15.5","SPDXID":"SPDXRef-Package--postgres","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/postgres@15.5?os_name=alpine&os_version=3.18"}],"licenseDeclared":"PostgreSQL"}]}' > /usr/local/postgres.spdx.json \
-	; \
+	\
 	postgres --version
 
 # make the sample config easier to munge (and "correct by default")

--- a/15/alpine3.19/Dockerfile
+++ b/15/alpine3.19/Dockerfile
@@ -4,7 +4,6 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-
 FROM alpine:3.19
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -158,8 +157,7 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"postgres-sbom","packages":[{"name":"postgres","versionInfo":"15.5","SPDXID":"SPDXRef-Package--postgres","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/postgres@15.5?os_name=alpine&os_version=3.19"}],"licenseDeclared":"PostgreSQL"}]}' > /usr/local/postgres.spdx.json \
-	; \
+	\
 	postgres --version
 
 # make the sample config easier to munge (and "correct by default")

--- a/16/alpine3.18/Dockerfile
+++ b/16/alpine3.18/Dockerfile
@@ -4,7 +4,6 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-
 FROM alpine:3.18
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -157,8 +156,7 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"postgres-sbom","packages":[{"name":"postgres","versionInfo":"16.1","SPDXID":"SPDXRef-Package--postgres","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/postgres@16.1?os_name=alpine&os_version=3.18"}],"licenseDeclared":"PostgreSQL"}]}' > /usr/local/postgres.spdx.json \
-	; \
+	\
 	postgres --version
 
 # make the sample config easier to munge (and "correct by default")

--- a/16/alpine3.19/Dockerfile
+++ b/16/alpine3.19/Dockerfile
@@ -4,7 +4,6 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-
 FROM alpine:3.19
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -157,8 +156,7 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"postgres-sbom","packages":[{"name":"postgres","versionInfo":"16.1","SPDXID":"SPDXRef-Package--postgres","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/postgres@16.1?os_name=alpine&os_version=3.19"}],"licenseDeclared":"PostgreSQL"}]}' > /usr/local/postgres.spdx.json \
-	; \
+	\
 	postgres --version
 
 # make the sample config easier to munge (and "correct by default")

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,4 +1,3 @@
-{{ include "template-helper-functions" }}
 FROM alpine:{{ env.variant | ltrimstr("alpine") }}
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -165,20 +164,7 @@ RUN set -eux; \
 		/usr/local/share/doc \
 		/usr/local/share/man \
 	; \
-	echo '{{
-		{
-			name: "postgres",
-			version: .version,
-			params: {
-				os_name: "alpine",
-				os_version: env.variant | ltrimstr("alpine"),
-			},
-			licenses: [
-				"PostgreSQL"
-			]
-		} | sbom | tostring
-	}}' > /usr/local/postgres.spdx.json \
-	; \
+	\
 	postgres --version
 
 # make the sample config easier to munge (and "correct by default")

--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -13,11 +13,6 @@ elif [ "$BASH_SOURCE" -nt "$jqt" ]; then
 	wget -qO "$jqt" 'https://github.com/docker-library/bashbrew/raw/9f6a35772ac863a0241f147c820354e4008edf38/scripts/jq-template.awk'
 fi
 
-jqf='template-helper-functions.jq'
-if [ "$BASH_SOURCE" -nt "$jqf" ]; then
-	wget -qO "$jqf" 'https://github.com/docker-library/bashbrew/raw/master/scripts/template-helper-functions.jq'
-fi
-
 if [ "$#" -eq 0 ]; then
 	versions="$(jq -r 'keys | map(@sh) | join(" ")' versions.json)"
 	eval "set -- $versions"


### PR DESCRIPTION
This reverts commit 6f4ae836406b010948f01fbcb400a31dca4fdf52.

This is now supported by the Syft Scanner