### PR TITLE
Add `less` to Debian variants

### DIFF
--- a/12/bookworm/Dockerfile
+++ b/12/bookworm/Dockerfile
@@ -20,6 +20,10 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		gnupg \
+# https://www.postgresql.org/docs/16/app-psql.html#APP-PSQL-META-COMMAND-PSET-PAGER
+# https://github.com/postgres/postgres/blob/REL_16_1/src/include/fe_utils/print.h#L25
+# (if "less" is available, it gets used as the default pager for psql, and it only adds ~1.5MiB to our image size)
+		less \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/12/bullseye/Dockerfile
+++ b/12/bullseye/Dockerfile
@@ -20,6 +20,10 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		gnupg \
+# https://www.postgresql.org/docs/16/app-psql.html#APP-PSQL-META-COMMAND-PSET-PAGER
+# https://github.com/postgres/postgres/blob/REL_16_1/src/include/fe_utils/print.h#L25
+# (if "less" is available, it gets used as the default pager for psql, and it only adds ~1.5MiB to our image size)
+		less \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/13/bookworm/Dockerfile
+++ b/13/bookworm/Dockerfile
@@ -20,6 +20,10 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		gnupg \
+# https://www.postgresql.org/docs/16/app-psql.html#APP-PSQL-META-COMMAND-PSET-PAGER
+# https://github.com/postgres/postgres/blob/REL_16_1/src/include/fe_utils/print.h#L25
+# (if "less" is available, it gets used as the default pager for psql, and it only adds ~1.5MiB to our image size)
+		less \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/13/bullseye/Dockerfile
+++ b/13/bullseye/Dockerfile
@@ -20,6 +20,10 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		gnupg \
+# https://www.postgresql.org/docs/16/app-psql.html#APP-PSQL-META-COMMAND-PSET-PAGER
+# https://github.com/postgres/postgres/blob/REL_16_1/src/include/fe_utils/print.h#L25
+# (if "less" is available, it gets used as the default pager for psql, and it only adds ~1.5MiB to our image size)
+		less \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/14/bookworm/Dockerfile
+++ b/14/bookworm/Dockerfile
@@ -20,6 +20,10 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		gnupg \
+# https://www.postgresql.org/docs/16/app-psql.html#APP-PSQL-META-COMMAND-PSET-PAGER
+# https://github.com/postgres/postgres/blob/REL_16_1/src/include/fe_utils/print.h#L25
+# (if "less" is available, it gets used as the default pager for psql, and it only adds ~1.5MiB to our image size)
+		less \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/14/bullseye/Dockerfile
+++ b/14/bullseye/Dockerfile
@@ -20,6 +20,10 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		gnupg \
+# https://www.postgresql.org/docs/16/app-psql.html#APP-PSQL-META-COMMAND-PSET-PAGER
+# https://github.com/postgres/postgres/blob/REL_16_1/src/include/fe_utils/print.h#L25
+# (if "less" is available, it gets used as the default pager for psql, and it only adds ~1.5MiB to our image size)
+		less \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/15/bookworm/Dockerfile
+++ b/15/bookworm/Dockerfile
@@ -20,6 +20,10 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		gnupg \
+# https://www.postgresql.org/docs/16/app-psql.html#APP-PSQL-META-COMMAND-PSET-PAGER
+# https://github.com/postgres/postgres/blob/REL_16_1/src/include/fe_utils/print.h#L25
+# (if "less" is available, it gets used as the default pager for psql, and it only adds ~1.5MiB to our image size)
+		less \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/15/bullseye/Dockerfile
+++ b/15/bullseye/Dockerfile
@@ -20,6 +20,10 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		gnupg \
+# https://www.postgresql.org/docs/16/app-psql.html#APP-PSQL-META-COMMAND-PSET-PAGER
+# https://github.com/postgres/postgres/blob/REL_16_1/src/include/fe_utils/print.h#L25
+# (if "less" is available, it gets used as the default pager for psql, and it only adds ~1.5MiB to our image size)
+		less \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/16/bookworm/Dockerfile
+++ b/16/bookworm/Dockerfile
@@ -20,6 +20,10 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		gnupg \
+# https://www.postgresql.org/docs/16/app-psql.html#APP-PSQL-META-COMMAND-PSET-PAGER
+# https://github.com/postgres/postgres/blob/REL_16_1/src/include/fe_utils/print.h#L25
+# (if "less" is available, it gets used as the default pager for psql, and it only adds ~1.5MiB to our image size)
+		less \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/16/bullseye/Dockerfile
+++ b/16/bullseye/Dockerfile
@@ -20,6 +20,10 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		gnupg \
+# https://www.postgresql.org/docs/16/app-psql.html#APP-PSQL-META-COMMAND-PSET-PAGER
+# https://github.com/postgres/postgres/blob/REL_16_1/src/include/fe_utils/print.h#L25
+# (if "less" is available, it gets used as the default pager for psql, and it only adds ~1.5MiB to our image size)
+		less \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -14,6 +14,10 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		gnupg \
+# https://www.postgresql.org/docs/16/app-psql.html#APP-PSQL-META-COMMAND-PSET-PAGER
+# https://github.com/postgres/postgres/blob/REL_16_1/src/include/fe_utils/print.h#L25
+# (if "less" is available, it gets used as the default pager for psql, and it only adds ~1.5MiB to our image size)
+		less \
 	; \
 	rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
https://www.postgresql.org/docs/16/app-psql.html#APP-PSQL-META-COMMAND-PSET-PAGER https://github.com/postgres/postgres/blob/REL_16_1/src/include/fe_utils/print.h#L25
(if "less" is available, it gets used as the default pager for psql, and it only adds ~1.5MiB to our image size)

Closes #1115