### PR TITLE
Bump `actions/checkout` to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: docker-library/bashbrew@HEAD
       - id: generate-jobs
         name: Generate Jobs
@@ -35,7 +35,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare Environment
         run: ${{ matrix.runs.prepare }}
       - name: Pull Dependencies

--- a/.github/workflows/verify-templating.yml
+++ b/.github/workflows/verify-templating.yml
@@ -14,7 +14,7 @@ jobs:
     name: Check For Uncomitted Changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Apply Templates
         run: ./apply-templates.sh
       - name: Check Git Status


### PR DESCRIPTION
Prevents a Node.js 16 deprecation warning

https://github.com/docker-library/postgres/actions/runs/9198118729
![image](https://github.com/docker-library/postgres/assets/14981592/bb586d0d-0f75-4d84-a2da-aac3b095f8cb)
