### PR TITLE
Enable Config Include in default configuration

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -203,9 +203,11 @@ RUN set -eux; \
 
 # make the sample config easier to munge (and "correct by default")
 RUN set -eux; \
-	cp -v /usr/local/share/postgresql/postgresql.conf.sample /usr/local/share/postgresql/postgresql.conf.sample.orig; \
+	mkdir -p /etc/postgresql/conf.d; \
+	mv -v /usr/local/share/postgresql/postgresql.conf.sample /usr/local/share/postgresql/postgresql.conf.sample.orig; \
+    awk '/# CONFIG FILE INCLUDES/ {print; getline; print; print "\ninclude_dir = '\''/etc/postgresql/conf.d'\''"; next} 1' /usr/local/share/postgresql/postgresql.conf.sample.orig > /usr/local/share/postgresql/postgresql.conf.sample; \
 	sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/local/share/postgresql/postgresql.conf.sample; \
-	grep -F "listen_addresses = '*'" /usr/local/share/postgresql/postgresql.conf.sample
+	grep -F "listen_addresses = '*'" /usr/local/share/postgresql/postgresql.conf.samplee
 
 RUN install --verbose --directory --owner postgres --group postgres --mode 3777 /var/run/postgresql
 

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -173,10 +173,11 @@ RUN set -ex; \
 # make the sample config easier to munge (and "correct by default")
 RUN set -eux; \
 	dpkg-divert --add --rename --divert "/usr/share/postgresql/postgresql.conf.sample.dpkg" "/usr/share/postgresql/$PG_MAJOR/postgresql.conf.sample"; \
-	cp -v /usr/share/postgresql/postgresql.conf.sample.dpkg /usr/share/postgresql/postgresql.conf.sample; \
-	ln -sv ../postgresql.conf.sample "/usr/share/postgresql/$PG_MAJOR/"; \
+	mkdir -p /etc/postgresql/conf.d; \
+	awk '/# CONFIG FILE INCLUDES/ {print; getline; print; print "\ninclude_dir = '\''/etc/postgresql/conf.d'\''"; next} 1' /usr/share/postgresql/postgresql.conf.sample.dpkg > /usr/share/postgresql/postgresql.conf.sample; \
 	sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/share/postgresql/postgresql.conf.sample; \
-	grep -F "listen_addresses = '*'" /usr/share/postgresql/postgresql.conf.sample
+	grep -F "listen_addresses = '*'" /usr/share/postgresql/postgresql.conf.sample; \
+	ln -sv ../postgresql.conf.sample "/usr/share/postgresql/$PG_MAJOR/";
 
 RUN install --verbose --directory --owner postgres --group postgres --mode 3777 /var/run/postgresql
 


### PR DESCRIPTION
Yesterday, I was debugging a query in our application (with docker compose) and tried to enable some logs. A common pattern for this is to load a config file to some directory, that leaves default config intact but adds some parameters (I use Nginx and PHP containers, for example). So, I was very surprised that enabling some parameters is so hard to do with the Postgres image: it's required to maintain your own config fork, and then it's also required to change the default command?!

---

I did quick research, and learned, that Postgres also can include files of a directory as additional config. Therefore I created this PR to enable a similar experience in this container as well.

I implemented it in a similar way to what is already used to configure the `listen_addresses`. With this change, it might not be needed to do it that way and we could as well just use a default configuration. I’m up for both, just let me know if I should implement it differently.

Basically, all this PR does is add the creation of the directory `/etc/postgresql/conf.d` and insert the line `include_dir = 'etc/postgresql/conf.d'` into the default config.

---

With the suggested changes, it would be way easier to maintain and load one or even multiple config files, especially in local docker compose environments:
For example:

```yaml
services:
  pg_configdir:
    image: postgres
    volumes:
     - db:/var/lib/postgresql/data
     - ${PWD}/config/postgresql/local/:/etc/postgresql/conf.d

  pg_configfiles:
    image: postgres
    volumes:
     - db:/var/lib/postgresql/data
     - ${PWD}/config/postgresql/local/default.conf:/etc/postgresql/conf.d/10-default.conf
     # - ${PWD}/config/postgresql/local/debug.conf:/etc/postgresql/conf.d/99-default.conf   #optional: enable only for debugging
```