### PR TITLE
Add `HEALTHCHECK` instruction to `Dockerfile`

### DIFF
--- a/12/alpine3.19/Dockerfile
+++ b/12/alpine3.19/Dockerfile
@@ -232,3 +232,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/12/alpine3.20/Dockerfile
+++ b/12/alpine3.20/Dockerfile
@@ -232,3 +232,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/12/bookworm/Dockerfile
+++ b/12/bookworm/Dockerfile
@@ -223,3 +223,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/12/bullseye/Dockerfile
+++ b/12/bullseye/Dockerfile
@@ -223,3 +223,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/13/alpine3.19/Dockerfile
+++ b/13/alpine3.19/Dockerfile
@@ -232,3 +232,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/13/alpine3.20/Dockerfile
+++ b/13/alpine3.20/Dockerfile
@@ -232,3 +232,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/13/bookworm/Dockerfile
+++ b/13/bookworm/Dockerfile
@@ -225,3 +225,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/13/bullseye/Dockerfile
+++ b/13/bullseye/Dockerfile
@@ -225,3 +225,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/14/alpine3.19/Dockerfile
+++ b/14/alpine3.19/Dockerfile
@@ -235,3 +235,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/14/alpine3.20/Dockerfile
+++ b/14/alpine3.20/Dockerfile
@@ -235,3 +235,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/14/bookworm/Dockerfile
+++ b/14/bookworm/Dockerfile
@@ -223,3 +223,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/14/bullseye/Dockerfile
+++ b/14/bullseye/Dockerfile
@@ -223,3 +223,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/15/alpine3.19/Dockerfile
+++ b/15/alpine3.19/Dockerfile
@@ -238,3 +238,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/15/alpine3.20/Dockerfile
+++ b/15/alpine3.20/Dockerfile
@@ -238,3 +238,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/15/bookworm/Dockerfile
+++ b/15/bookworm/Dockerfile
@@ -223,3 +223,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/15/bullseye/Dockerfile
+++ b/15/bullseye/Dockerfile
@@ -223,3 +223,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/16/alpine3.19/Dockerfile
+++ b/16/alpine3.19/Dockerfile
@@ -237,3 +237,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/16/alpine3.20/Dockerfile
+++ b/16/alpine3.20/Dockerfile
@@ -237,3 +237,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/16/bookworm/Dockerfile
+++ b/16/bookworm/Dockerfile
@@ -223,3 +223,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/16/bullseye/Dockerfile
+++ b/16/bullseye/Dockerfile
@@ -223,3 +223,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/17/alpine3.19/Dockerfile
+++ b/17/alpine3.19/Dockerfile
@@ -235,3 +235,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/17/alpine3.20/Dockerfile
+++ b/17/alpine3.20/Dockerfile
@@ -235,3 +235,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/17/bookworm/Dockerfile
+++ b/17/bookworm/Dockerfile
@@ -223,3 +223,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -223,3 +223,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -250,3 +250,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -221,3 +221,5 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 CMD ["postgres"]
+
+HEALTHCHECK --start-period=1s CMD pg_isready || exit 1


### PR DESCRIPTION
The `Dockerfile` currently does not have a `HEALTHCHECK` instruction. Users of the Docker image currently need to add it manually (e.g. via Docker Compose). Instead, the `Dockerfile` itself should include the instruction.

To determine whether the service is healthy, one can use the [`pg_isready`](https://www.postgresql.org/docs/current/app-pg-isready.html) program, which is already part of the image. The program “checks the connection status of a PostgreSQL database server”.

Most of the default `HEALTHCHECK` [options](https://docs.docker.com/reference/dockerfile/#healthcheck) seem reasonable:
```
--interval=30s
--timeout=30s
--start-interval=5s
--retries=3
```

I set `--start-period=1s` because the default of `0s` is too quick for this program.

Users of the image can still override the `HEALTHCHECK` instruction if they want to customize the command or the options.