### PR TITLE
Use jq's `IN()` instead of `index()`

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -38,7 +38,7 @@ RUN set -eux; \
 # verify that the binary works
 	gosu --version; \
 	gosu nobody true
-{{ if [ "12", "13", "14", "15", "16" ] | index(env.version) then ( -}}
+{{ if env.version | IN("12", "13", "14", "15", "16") then ( -}}
 RUN set -eux; ln -svf gosu /usr/local/bin/su-exec; su-exec nobody true # backwards compatibility (removed in PostgreSQL 17+)
 {{ ) else "" end -}}
 


### PR DESCRIPTION
The end result is the same, but the construction is more ergonomic.

See also https://github.com/docker-library/buildpack-deps/pull/165 (and linked)