### PR TITLE
Remove "latest" and friends

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,7 +2,7 @@
 set -Eeuo pipefail
 
 declare -A aliases=(
-	[17]='latest'
+	#[9.6]='9'
 )
 
 self="$(basename "$BASH_SOURCE")"


### PR DESCRIPTION
Major version upgrades in PostgreSQL are complicated (#37, most recently https://github.com/docker-library/postgres/issues/1293), and no users should be pulling a version of PostgreSQL without explicitly specifying an intentional major version (thus avoiding tools like compose or watchtower from naïvely "upgrading" them and breaking the database).