### PR TITLE
Remove gosu based CVE by building gosu with current golang image

### DIFF
--- a/13/alpine3.20/Dockerfile
+++ b/13/alpine3.20/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM alpine:3.20
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -16,29 +24,17 @@ RUN set -eux; \
 	install --verbose --directory --owner postgres --group postgres --mode 1777 /var/lib/postgresql
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .gosu-deps \
+	apk add --no-cache --virtual \
 		ca-certificates \
 		dpkg \
 		gnupg \
 	; \
 	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	\
-# verify the signature
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	\
 # clean up fetch dependencies
-	apk del --no-network .gosu-deps; \
 	\
 	chmod +x /usr/local/bin/gosu; \
 # verify that the binary works

--- a/13/alpine3.21/Dockerfile
+++ b/13/alpine3.21/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM alpine:3.21
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -16,29 +24,17 @@ RUN set -eux; \
 	install --verbose --directory --owner postgres --group postgres --mode 1777 /var/lib/postgresql
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .gosu-deps \
+	apk add --no-cache --virtual \
 		ca-certificates \
 		dpkg \
 		gnupg \
 	; \
 	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	\
-# verify the signature
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	\
 # clean up fetch dependencies
-	apk del --no-network .gosu-deps; \
 	\
 	chmod +x /usr/local/bin/gosu; \
 # verify that the binary works

--- a/13/bookworm/Dockerfile
+++ b/13/bookworm/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM debian:bookworm-slim
 
 # explicitly set user/group IDs
@@ -27,21 +35,14 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends ca-certificates wget; \
 	rm -rf /var/lib/apt/lists/*; \
 	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \

--- a/13/bullseye/Dockerfile
+++ b/13/bullseye/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM debian:bullseye-slim
 
 # explicitly set user/group IDs
@@ -27,21 +35,14 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends ca-certificates wget; \
 	rm -rf /var/lib/apt/lists/*; \
 	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \

--- a/14/alpine3.20/Dockerfile
+++ b/14/alpine3.20/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM alpine:3.20
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -16,29 +24,17 @@ RUN set -eux; \
 	install --verbose --directory --owner postgres --group postgres --mode 1777 /var/lib/postgresql
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .gosu-deps \
+	apk add --no-cache --virtual \
 		ca-certificates \
 		dpkg \
 		gnupg \
 	; \
 	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	\
-# verify the signature
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	\
 # clean up fetch dependencies
-	apk del --no-network .gosu-deps; \
 	\
 	chmod +x /usr/local/bin/gosu; \
 # verify that the binary works

--- a/14/alpine3.21/Dockerfile
+++ b/14/alpine3.21/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM alpine:3.21
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -16,29 +24,17 @@ RUN set -eux; \
 	install --verbose --directory --owner postgres --group postgres --mode 1777 /var/lib/postgresql
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .gosu-deps \
+	apk add --no-cache --virtual \
 		ca-certificates \
 		dpkg \
 		gnupg \
 	; \
 	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	\
-# verify the signature
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	\
 # clean up fetch dependencies
-	apk del --no-network .gosu-deps; \
 	\
 	chmod +x /usr/local/bin/gosu; \
 # verify that the binary works

--- a/14/bookworm/Dockerfile
+++ b/14/bookworm/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM debian:bookworm-slim
 
 # explicitly set user/group IDs
@@ -27,21 +35,14 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends ca-certificates wget; \
 	rm -rf /var/lib/apt/lists/*; \
 	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \

--- a/14/bullseye/Dockerfile
+++ b/14/bullseye/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM debian:bullseye-slim
 
 # explicitly set user/group IDs
@@ -27,21 +35,14 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends ca-certificates wget; \
 	rm -rf /var/lib/apt/lists/*; \
 	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \

--- a/15/alpine3.20/Dockerfile
+++ b/15/alpine3.20/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM alpine:3.20
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -16,29 +24,17 @@ RUN set -eux; \
 	install --verbose --directory --owner postgres --group postgres --mode 1777 /var/lib/postgresql
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .gosu-deps \
+	apk add --no-cache --virtual \
 		ca-certificates \
 		dpkg \
 		gnupg \
 	; \
 	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	\
-# verify the signature
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	\
 # clean up fetch dependencies
-	apk del --no-network .gosu-deps; \
 	\
 	chmod +x /usr/local/bin/gosu; \
 # verify that the binary works

--- a/15/alpine3.21/Dockerfile
+++ b/15/alpine3.21/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM alpine:3.21
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -16,29 +24,17 @@ RUN set -eux; \
 	install --verbose --directory --owner postgres --group postgres --mode 1777 /var/lib/postgresql
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .gosu-deps \
+	apk add --no-cache --virtual \
 		ca-certificates \
 		dpkg \
 		gnupg \
 	; \
 	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	\
-# verify the signature
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	\
 # clean up fetch dependencies
-	apk del --no-network .gosu-deps; \
 	\
 	chmod +x /usr/local/bin/gosu; \
 # verify that the binary works

--- a/15/bookworm/Dockerfile
+++ b/15/bookworm/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM debian:bookworm-slim
 
 # explicitly set user/group IDs
@@ -27,21 +35,14 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends ca-certificates wget; \
 	rm -rf /var/lib/apt/lists/*; \
 	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \

--- a/15/bullseye/Dockerfile
+++ b/15/bullseye/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM debian:bullseye-slim
 
 # explicitly set user/group IDs
@@ -27,21 +35,14 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends ca-certificates wget; \
 	rm -rf /var/lib/apt/lists/*; \
 	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \

--- a/16/alpine3.20/Dockerfile
+++ b/16/alpine3.20/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM alpine:3.20
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -16,29 +24,17 @@ RUN set -eux; \
 	install --verbose --directory --owner postgres --group postgres --mode 1777 /var/lib/postgresql
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .gosu-deps \
+	apk add --no-cache --virtual \
 		ca-certificates \
 		dpkg \
 		gnupg \
 	; \
 	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	\
-# verify the signature
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	\
 # clean up fetch dependencies
-	apk del --no-network .gosu-deps; \
 	\
 	chmod +x /usr/local/bin/gosu; \
 # verify that the binary works

--- a/16/alpine3.21/Dockerfile
+++ b/16/alpine3.21/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM alpine:3.21
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -16,29 +24,17 @@ RUN set -eux; \
 	install --verbose --directory --owner postgres --group postgres --mode 1777 /var/lib/postgresql
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .gosu-deps \
+	apk add --no-cache --virtual \
 		ca-certificates \
 		dpkg \
 		gnupg \
 	; \
 	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	\
-# verify the signature
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	\
 # clean up fetch dependencies
-	apk del --no-network .gosu-deps; \
 	\
 	chmod +x /usr/local/bin/gosu; \
 # verify that the binary works

--- a/16/bookworm/Dockerfile
+++ b/16/bookworm/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM debian:bookworm-slim
 
 # explicitly set user/group IDs
@@ -27,21 +35,14 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends ca-certificates wget; \
 	rm -rf /var/lib/apt/lists/*; \
 	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \

--- a/16/bullseye/Dockerfile
+++ b/16/bullseye/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM debian:bullseye-slim
 
 # explicitly set user/group IDs
@@ -27,21 +35,14 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends ca-certificates wget; \
 	rm -rf /var/lib/apt/lists/*; \
 	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \

--- a/17/alpine3.20/Dockerfile
+++ b/17/alpine3.20/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM alpine:3.20
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -16,29 +24,17 @@ RUN set -eux; \
 	install --verbose --directory --owner postgres --group postgres --mode 1777 /var/lib/postgresql
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .gosu-deps \
+	apk add --no-cache --virtual \
 		ca-certificates \
 		dpkg \
 		gnupg \
 	; \
 	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	\
-# verify the signature
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	\
 # clean up fetch dependencies
-	apk del --no-network .gosu-deps; \
 	\
 	chmod +x /usr/local/bin/gosu; \
 # verify that the binary works

--- a/17/alpine3.21/Dockerfile
+++ b/17/alpine3.21/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM alpine:3.21
 
 # 70 is the standard uid/gid for "postgres" in Alpine
@@ -16,29 +24,17 @@ RUN set -eux; \
 	install --verbose --directory --owner postgres --group postgres --mode 1777 /var/lib/postgresql
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .gosu-deps \
+	apk add --no-cache --virtual \
 		ca-certificates \
 		dpkg \
 		gnupg \
 	; \
 	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	\
-# verify the signature
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	\
 # clean up fetch dependencies
-	apk del --no-network .gosu-deps; \
 	\
 	chmod +x /usr/local/bin/gosu; \
 # verify that the binary works

--- a/17/bookworm/Dockerfile
+++ b/17/bookworm/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM debian:bookworm-slim
 
 # explicitly set user/group IDs
@@ -27,21 +35,14 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends ca-certificates wget; \
 	rm -rf /var/lib/apt/lists/*; \
 	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -4,6 +4,14 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM debian:bullseye-slim
 
 # explicitly set user/group IDs
@@ -27,21 +35,14 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends ca-certificates wget; \
 	rm -rf /var/lib/apt/lists/*; \
 	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,3 +1,11 @@
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 {{
 	def alpine_version:
 		env.variant | ltrimstr("alpine")
@@ -14,29 +22,17 @@ RUN set -eux; \
 	install --verbose --directory --owner postgres --group postgres --mode 1777 /var/lib/postgresql
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .gosu-deps \
+	apk add --no-cache --virtual \
 		ca-certificates \
 		dpkg \
 		gnupg \
 	; \
 	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	\
-# verify the signature
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	\
 # clean up fetch dependencies
-	apk del --no-network .gosu-deps; \
 	\
 	chmod +x /usr/local/bin/gosu; \
 # verify that the binary works

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,3 +1,11 @@
+FROM golang:1.23.6 AS gosubuilder
+ENV GOSU_VERSION=1.17
+WORKDIR /go/src/github.com/tianon
+RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION
+WORKDIR /go/src/github.com/tianon/gosu
+RUN go mod download
+RUN go build
+
 FROM debian:{{ env.variant }}-slim
 
 # explicitly set user/group IDs
@@ -21,21 +29,14 @@ RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+COPY --from=gosubuilder /go/src/github.com/tianon/gosu/gosu /usr/local/bin/gosu
+
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends ca-certificates wget; \
 	rm -rf /var/lib/apt/lists/*; \
 	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \


### PR DESCRIPTION
gosu security policy https://github.com/tianon/gosu/blob/master/SECURITY.md says they don't update golang for CVE's
So gosu is build with a unsupported version of go (1.20)
The two support go versions that have the most CVE's resolved are 1.23.6 and 1.24.0
I felt using 1.23.6 was a safer upgrade.

Your own documents talk about gosu, and I believe gosu hase a fundamental misunderstanding about what a vulnerability free  govulncheck means.  I understand it to mean that you don't have any external dependencies with vulnerabilities, not that you shouldn't update compiler versions.  They are 2 different things.

This PR removes the CVE caused by gosu by doing a custom build of gosu with a currently supported go version.
And copies it into the final image.

trivy image --scanners vuln 
shows that we'll get rid of the following CVE's

usr/local/bin/gosu (gobinary)

Total: 58 (UNKNOWN: 0, LOW: 1, MEDIUM: 23, HIGH: 31, CRITICAL: 3)

Thanks for your consideration