### PR TITLE
Unset NOTIFY_SOCKET when running the temporary server.

### DIFF
--- a/13/alpine3.20/docker-entrypoint.sh
+++ b/13/alpine3.20/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/13/alpine3.20/docker-entrypoint.sh
+++ b/13/alpine3.20/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/13/alpine3.21/docker-entrypoint.sh
+++ b/13/alpine3.21/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/13/alpine3.21/docker-entrypoint.sh
+++ b/13/alpine3.21/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/13/bookworm/docker-entrypoint.sh
+++ b/13/bookworm/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/13/bookworm/docker-entrypoint.sh
+++ b/13/bookworm/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/13/bullseye/docker-entrypoint.sh
+++ b/13/bullseye/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/13/bullseye/docker-entrypoint.sh
+++ b/13/bullseye/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/14/alpine3.20/docker-entrypoint.sh
+++ b/14/alpine3.20/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/14/alpine3.20/docker-entrypoint.sh
+++ b/14/alpine3.20/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/14/alpine3.21/docker-entrypoint.sh
+++ b/14/alpine3.21/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/14/alpine3.21/docker-entrypoint.sh
+++ b/14/alpine3.21/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/14/bookworm/docker-entrypoint.sh
+++ b/14/bookworm/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/14/bookworm/docker-entrypoint.sh
+++ b/14/bookworm/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/14/bullseye/docker-entrypoint.sh
+++ b/14/bullseye/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/14/bullseye/docker-entrypoint.sh
+++ b/14/bullseye/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/15/alpine3.20/docker-entrypoint.sh
+++ b/15/alpine3.20/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/15/alpine3.20/docker-entrypoint.sh
+++ b/15/alpine3.20/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/15/alpine3.21/docker-entrypoint.sh
+++ b/15/alpine3.21/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/15/alpine3.21/docker-entrypoint.sh
+++ b/15/alpine3.21/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/15/bookworm/docker-entrypoint.sh
+++ b/15/bookworm/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/15/bookworm/docker-entrypoint.sh
+++ b/15/bookworm/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/15/bullseye/docker-entrypoint.sh
+++ b/15/bullseye/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/15/bullseye/docker-entrypoint.sh
+++ b/15/bullseye/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/16/alpine3.20/docker-entrypoint.sh
+++ b/16/alpine3.20/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/16/alpine3.20/docker-entrypoint.sh
+++ b/16/alpine3.20/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/16/alpine3.21/docker-entrypoint.sh
+++ b/16/alpine3.21/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/16/alpine3.21/docker-entrypoint.sh
+++ b/16/alpine3.21/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/16/bookworm/docker-entrypoint.sh
+++ b/16/bookworm/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/16/bookworm/docker-entrypoint.sh
+++ b/16/bookworm/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/16/bullseye/docker-entrypoint.sh
+++ b/16/bullseye/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/16/bullseye/docker-entrypoint.sh
+++ b/16/bullseye/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/17/alpine3.20/docker-entrypoint.sh
+++ b/17/alpine3.20/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/17/alpine3.20/docker-entrypoint.sh
+++ b/17/alpine3.20/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/17/alpine3.21/docker-entrypoint.sh
+++ b/17/alpine3.21/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/17/alpine3.21/docker-entrypoint.sh
+++ b/17/alpine3.21/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/17/bookworm/docker-entrypoint.sh
+++ b/17/bookworm/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/17/bookworm/docker-entrypoint.sh
+++ b/17/bookworm/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/17/bullseye/docker-entrypoint.sh
+++ b/17/bullseye/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/17/bullseye/docker-entrypoint.sh
+++ b/17/bullseye/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -269,14 +269,13 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
 	# any process supervisor.
-	env \
-		--unset NOTIFY_SOCKET \
-		PGUSER="${PGUSER:-$POSTGRES_USER}" \
-		pg_ctl -D "$PGDATA" \
-			-o "$(printf '%q ' "$@")" \
-			-w start
+	NOTIFY_SOCKET= \
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
 }
 
 # stop postgresql server after done setting up user and running scripts

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -269,10 +269,14 @@ docker_temp_server_start() {
 	# does not listen on external TCP/IP and waits until start finishes
 	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
 
-	PGUSER="${PGUSER:-$POSTGRES_USER}" \
-	pg_ctl -D "$PGDATA" \
-		-o "$(printf '%q ' "$@")" \
-		-w start
+	# Unset NOTIFY_SOCKET so the temporary server doesn't prematurely notify
+	# any process supervisor.
+	env \
+		--unset NOTIFY_SOCKET \
+		PGUSER="${PGUSER:-$POSTGRES_USER}" \
+		pg_ctl -D "$PGDATA" \
+			-o "$(printf '%q ' "$@")" \
+			-w start
 }
 
 # stop postgresql server after done setting up user and running scripts


### PR DESCRIPTION
Some container runtimes, such as podman, can expose a notify socket when used in combination with systemd. The socket's path is available in the `NOTIFY_SOCKET` envirionment variable.

Postgres has native support for this notification socket, and will write a `READY=1` message once it is ready and accepting connections. Unfortunately, the temporary server used by the `docker-entrypoint.sh` to populate the database also sends a message on the socket, making it appear as though the container is ready and serving connections when it is not.

To avoid this issue we need to unset the NOTIFY_SOCKET envirionment variable before starting the temporary server. The real server will eventually find the socket and send the appropriate message.

The easiest way to test this is through the systemd-run command, which creates a transient service:

```sh
systemd-run --user --service-type=notify \
  podman run -e POSTGRES_PASSWORD=password postgres
```

When looking at the logs for this command, prior to this change systemd prints a "Started" message mid-way through the container startup (I've omitted a lot of irrelevant lines for the sake of brevity):

```
systemd[2970]: Starting run-r916adefbc19c4465a1b0afc892980bd6.service - /usr/bin/podman run --log-driver none -e POSTGRES_PASSWORD=password postgres...
[...]
podman[851405]: waiting for server to start....2025-02-25 17:37:39.378 UTC [48] LOG:  starting PostgreSQL 17.4 (Debian 17.4-1.pgdg120+2) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
podman[851405]: 2025-02-25 17:37:39.381 UTC [48] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
podman[851405]: 2025-02-25 17:37:39.393 UTC [51] LOG:  database system was shut down at 2025-02-25 17:37:39 UTC
podman[851405]: 2025-02-25 17:37:39.400 UTC [48] LOG:  database system is ready to accept connections
systemd[2970]: Started run-r916adefbc19c4465a1b0afc892980bd6.service - /usr/bin/podman run --log-driver none -e POSTGRES_PASSWORD=password postgres.
podman[851405]:  done
podman[851405]: server started
podman[851405]: /usr/local/bin/docker-entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
podman[851405]: waiting for server to shut down...2025-02-25 17:37:39.520 UTC [48] LOG:  received fast shutdown request
[...]
podman[851405]: 2025-02-25 17:37:39.556 UTC [48] LOG:  database system is shut down
podman[851405]:  done
podman[851405]: server stopped
podman[851405]: PostgreSQL init process complete; ready for start up.
podman[851405]: 2025-02-25 17:37:39.677 UTC [1] LOG:  starting PostgreSQL 17.4 (Debian 17.4-1.pgdg120+2) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
podman[851405]: 2025-02-25 17:37:39.677 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
podman[851405]: 2025-02-25 17:37:39.677 UTC [1] LOG:  listening on IPv6 address "::", port 5432
podman[851405]: 2025-02-25 17:37:39.684 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
podman[851405]: 2025-02-25 17:37:39.693 UTC [62] LOG:  database system was shut down at 2025-02-25 17:37:39 UTC
podman[851405]: 2025-02-25 17:37:39.700 UTC [1] LOG:  database system is ready to accept connections
```

After applying this change, the log output is very similar except the log line from systemd is moved to the very end, after the database server has started listening on the IPv4 and IPv6 addresses.