### PR TITLE
Update apt build depend

### DIFF
--- a/13/bookworm/Dockerfile
+++ b/13/bookworm/Dockerfile
@@ -131,10 +131,9 @@ RUN set -ex; \
 # build .deb files from upstream's source packages (which are verified by apt-get)
 			nproc="$(nproc)"; \
 			export DEB_BUILD_OPTIONS="nocheck parallel=$nproc"; \
-# we have to build postgresql-common first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/99f44476e258cae6bf9e919219fa2c5414fa2876
-# (and it "Depends: pgdg-keyring")
-			apt-get build-dep -y postgresql-common pgdg-keyring; \
-			apt-get source --compile postgresql-common pgdg-keyring; \
+# we have to build postgresql-common-dev first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/f4338a0d28cf4541956bddb0f4e444ba9dba81b9
+			apt-get build-dep -y postgresql-common-dev; \
+			apt-get source --compile postgresql-common-dev; \
 			_update_repo; \
 # we need DEBIAN_FRONTEND on postgresql-13 for slapd ("Please enter the password for the admin entry in your LDAP directory."); see https://bugs.debian.org/929417
 			DEBIAN_FRONTEND=noninteractive \

--- a/13/bullseye/Dockerfile
+++ b/13/bullseye/Dockerfile
@@ -131,10 +131,9 @@ RUN set -ex; \
 # build .deb files from upstream's source packages (which are verified by apt-get)
 			nproc="$(nproc)"; \
 			export DEB_BUILD_OPTIONS="nocheck parallel=$nproc"; \
-# we have to build postgresql-common first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/99f44476e258cae6bf9e919219fa2c5414fa2876
-# (and it "Depends: pgdg-keyring")
-			apt-get build-dep -y postgresql-common pgdg-keyring; \
-			apt-get source --compile postgresql-common pgdg-keyring; \
+# we have to build postgresql-common-dev first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/f4338a0d28cf4541956bddb0f4e444ba9dba81b9
+			apt-get build-dep -y postgresql-common-dev; \
+			apt-get source --compile postgresql-common-dev; \
 			_update_repo; \
 # we need DEBIAN_FRONTEND on postgresql-13 for slapd ("Please enter the password for the admin entry in your LDAP directory."); see https://bugs.debian.org/929417
 			DEBIAN_FRONTEND=noninteractive \

--- a/14/bookworm/Dockerfile
+++ b/14/bookworm/Dockerfile
@@ -131,10 +131,9 @@ RUN set -ex; \
 # build .deb files from upstream's source packages (which are verified by apt-get)
 			nproc="$(nproc)"; \
 			export DEB_BUILD_OPTIONS="nocheck parallel=$nproc"; \
-# we have to build postgresql-common first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/99f44476e258cae6bf9e919219fa2c5414fa2876
-# (and it "Depends: pgdg-keyring")
-			apt-get build-dep -y postgresql-common pgdg-keyring; \
-			apt-get source --compile postgresql-common pgdg-keyring; \
+# we have to build postgresql-common-dev first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/f4338a0d28cf4541956bddb0f4e444ba9dba81b9
+			apt-get build-dep -y postgresql-common-dev; \
+			apt-get source --compile postgresql-common-dev; \
 			_update_repo; \
 			apt-get build-dep -y "postgresql-$PG_MAJOR=$PG_VERSION"; \
 			apt-get source --compile "postgresql-$PG_MAJOR=$PG_VERSION"; \

--- a/14/bullseye/Dockerfile
+++ b/14/bullseye/Dockerfile
@@ -131,10 +131,9 @@ RUN set -ex; \
 # build .deb files from upstream's source packages (which are verified by apt-get)
 			nproc="$(nproc)"; \
 			export DEB_BUILD_OPTIONS="nocheck parallel=$nproc"; \
-# we have to build postgresql-common first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/99f44476e258cae6bf9e919219fa2c5414fa2876
-# (and it "Depends: pgdg-keyring")
-			apt-get build-dep -y postgresql-common pgdg-keyring; \
-			apt-get source --compile postgresql-common pgdg-keyring; \
+# we have to build postgresql-common-dev first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/f4338a0d28cf4541956bddb0f4e444ba9dba81b9
+			apt-get build-dep -y postgresql-common-dev; \
+			apt-get source --compile postgresql-common-dev; \
 			_update_repo; \
 			apt-get build-dep -y "postgresql-$PG_MAJOR=$PG_VERSION"; \
 			apt-get source --compile "postgresql-$PG_MAJOR=$PG_VERSION"; \

--- a/15/bookworm/Dockerfile
+++ b/15/bookworm/Dockerfile
@@ -131,10 +131,9 @@ RUN set -ex; \
 # build .deb files from upstream's source packages (which are verified by apt-get)
 			nproc="$(nproc)"; \
 			export DEB_BUILD_OPTIONS="nocheck parallel=$nproc"; \
-# we have to build postgresql-common first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/99f44476e258cae6bf9e919219fa2c5414fa2876
-# (and it "Depends: pgdg-keyring")
-			apt-get build-dep -y postgresql-common pgdg-keyring; \
-			apt-get source --compile postgresql-common pgdg-keyring; \
+# we have to build postgresql-common-dev first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/f4338a0d28cf4541956bddb0f4e444ba9dba81b9
+			apt-get build-dep -y postgresql-common-dev; \
+			apt-get source --compile postgresql-common-dev; \
 			_update_repo; \
 			apt-get build-dep -y "postgresql-$PG_MAJOR=$PG_VERSION"; \
 			apt-get source --compile "postgresql-$PG_MAJOR=$PG_VERSION"; \

--- a/15/bullseye/Dockerfile
+++ b/15/bullseye/Dockerfile
@@ -131,10 +131,9 @@ RUN set -ex; \
 # build .deb files from upstream's source packages (which are verified by apt-get)
 			nproc="$(nproc)"; \
 			export DEB_BUILD_OPTIONS="nocheck parallel=$nproc"; \
-# we have to build postgresql-common first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/99f44476e258cae6bf9e919219fa2c5414fa2876
-# (and it "Depends: pgdg-keyring")
-			apt-get build-dep -y postgresql-common pgdg-keyring; \
-			apt-get source --compile postgresql-common pgdg-keyring; \
+# we have to build postgresql-common-dev first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/f4338a0d28cf4541956bddb0f4e444ba9dba81b9
+			apt-get build-dep -y postgresql-common-dev; \
+			apt-get source --compile postgresql-common-dev; \
 			_update_repo; \
 			apt-get build-dep -y "postgresql-$PG_MAJOR=$PG_VERSION"; \
 			apt-get source --compile "postgresql-$PG_MAJOR=$PG_VERSION"; \

--- a/16/bookworm/Dockerfile
+++ b/16/bookworm/Dockerfile
@@ -131,10 +131,9 @@ RUN set -ex; \
 # build .deb files from upstream's source packages (which are verified by apt-get)
 			nproc="$(nproc)"; \
 			export DEB_BUILD_OPTIONS="nocheck parallel=$nproc"; \
-# we have to build postgresql-common first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/99f44476e258cae6bf9e919219fa2c5414fa2876
-# (and it "Depends: pgdg-keyring")
-			apt-get build-dep -y postgresql-common pgdg-keyring; \
-			apt-get source --compile postgresql-common pgdg-keyring; \
+# we have to build postgresql-common-dev first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/f4338a0d28cf4541956bddb0f4e444ba9dba81b9
+			apt-get build-dep -y postgresql-common-dev; \
+			apt-get source --compile postgresql-common-dev; \
 			_update_repo; \
 			apt-get build-dep -y "postgresql-$PG_MAJOR=$PG_VERSION"; \
 			apt-get source --compile "postgresql-$PG_MAJOR=$PG_VERSION"; \

--- a/16/bullseye/Dockerfile
+++ b/16/bullseye/Dockerfile
@@ -131,10 +131,9 @@ RUN set -ex; \
 # build .deb files from upstream's source packages (which are verified by apt-get)
 			nproc="$(nproc)"; \
 			export DEB_BUILD_OPTIONS="nocheck parallel=$nproc"; \
-# we have to build postgresql-common first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/99f44476e258cae6bf9e919219fa2c5414fa2876
-# (and it "Depends: pgdg-keyring")
-			apt-get build-dep -y postgresql-common pgdg-keyring; \
-			apt-get source --compile postgresql-common pgdg-keyring; \
+# we have to build postgresql-common-dev first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/f4338a0d28cf4541956bddb0f4e444ba9dba81b9
+			apt-get build-dep -y postgresql-common-dev; \
+			apt-get source --compile postgresql-common-dev; \
 			_update_repo; \
 			apt-get build-dep -y "postgresql-$PG_MAJOR=$PG_VERSION"; \
 			apt-get source --compile "postgresql-$PG_MAJOR=$PG_VERSION"; \

--- a/17/bookworm/Dockerfile
+++ b/17/bookworm/Dockerfile
@@ -131,10 +131,9 @@ RUN set -ex; \
 # build .deb files from upstream's source packages (which are verified by apt-get)
 			nproc="$(nproc)"; \
 			export DEB_BUILD_OPTIONS="nocheck parallel=$nproc"; \
-# we have to build postgresql-common first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/99f44476e258cae6bf9e919219fa2c5414fa2876
-# (and it "Depends: pgdg-keyring")
-			apt-get build-dep -y postgresql-common pgdg-keyring; \
-			apt-get source --compile postgresql-common pgdg-keyring; \
+# we have to build postgresql-common-dev first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/f4338a0d28cf4541956bddb0f4e444ba9dba81b9
+			apt-get build-dep -y postgresql-common-dev; \
+			apt-get source --compile postgresql-common-dev; \
 			_update_repo; \
 			apt-get build-dep -y "postgresql-$PG_MAJOR=$PG_VERSION"; \
 			apt-get source --compile "postgresql-$PG_MAJOR=$PG_VERSION"; \

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -131,10 +131,9 @@ RUN set -ex; \
 # build .deb files from upstream's source packages (which are verified by apt-get)
 			nproc="$(nproc)"; \
 			export DEB_BUILD_OPTIONS="nocheck parallel=$nproc"; \
-# we have to build postgresql-common first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/99f44476e258cae6bf9e919219fa2c5414fa2876
-# (and it "Depends: pgdg-keyring")
-			apt-get build-dep -y postgresql-common pgdg-keyring; \
-			apt-get source --compile postgresql-common pgdg-keyring; \
+# we have to build postgresql-common-dev first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/f4338a0d28cf4541956bddb0f4e444ba9dba81b9
+			apt-get build-dep -y postgresql-common-dev; \
+			apt-get source --compile postgresql-common-dev; \
 			_update_repo; \
 			apt-get build-dep -y "postgresql-$PG_MAJOR=$PG_VERSION"; \
 			apt-get source --compile "postgresql-$PG_MAJOR=$PG_VERSION"; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -125,10 +125,9 @@ RUN set -ex; \
 # build .deb files from upstream's source packages (which are verified by apt-get)
 			nproc="$(nproc)"; \
 			export DEB_BUILD_OPTIONS="nocheck parallel=$nproc"; \
-# we have to build postgresql-common first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/99f44476e258cae6bf9e919219fa2c5414fa2876
-# (and it "Depends: pgdg-keyring")
-			apt-get build-dep -y postgresql-common pgdg-keyring; \
-			apt-get source --compile postgresql-common pgdg-keyring; \
+# we have to build postgresql-common-dev first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/f4338a0d28cf4541956bddb0f4e444ba9dba81b9
+			apt-get build-dep -y postgresql-common-dev; \
+			apt-get source --compile postgresql-common-dev; \
 			_update_repo; \
 {{ if .major == 13 then ( -}}
 # we need DEBIAN_FRONTEND on postgresql-13 for slapd ("Please enter the password for the admin entry in your LDAP directory."); see https://bugs.debian.org/929417


### PR DESCRIPTION
>B-D on postgresql-common-dev.
>\- https://salsa.debian.org/postgresql/postgresql/-/commit/f4338a0d28cf4541956bddb0f4e444ba9dba81b9

This should fix our failing builds on arches that build the apt packages.

> ```
> E: Unable to find a source package for pgdg-keyring
> ```

2022-11-11: Repository key handling changed: https://www.postgresql.org/message-id/Y25%2BRkZxiZKBOKio%40msg.df7cb.de

> In postgresql-common 246, this has been changed such that
> postgresql-common itself contains the key files, and the trusted.gpg.d
> symlink is created when a /etc/apt/sources.list.d/pgdg.list is found.

2025-02-20: https://www.postgresql.org/message-id/E1tl6i4-00AYNF-P6@atalia.postgresql.org
>   * Move pgdg-keyring conflicts to postgresql-client-common where the files
>    are located now.


