### PR TITLE
Only install 18+ JIT package on architectures where it's supported

### DIFF
--- a/18/bookworm/Dockerfile
+++ b/18/bookworm/Dockerfile
@@ -156,9 +156,11 @@ RUN set -ex; \
 	sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf; \
 	apt-get install -y --no-install-recommends \
 		"postgresql-$PG_MAJOR=$PG_VERSION" \
-# https://github.com/docker-library/postgres/pull/1344#issuecomment-2936578203 (JIT is a separate package in 18+)
-		"postgresql-$PG_MAJOR-jit=$PG_VERSION" \
 	; \
+# https://github.com/docker-library/postgres/pull/1344#issuecomment-2936578203 (JIT is a separate package in 18+, but only supported for a subset of architectures)
+	if apt-get install -s "postgresql-$PG_MAJOR-jit" > /dev/null 2>&1; then \
+		apt-get install -y --no-install-recommends "postgresql-$PG_MAJOR-jit=$PG_VERSION"; \
+	fi; \
 	\
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/18/bullseye/Dockerfile
+++ b/18/bullseye/Dockerfile
@@ -156,9 +156,11 @@ RUN set -ex; \
 	sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf; \
 	apt-get install -y --no-install-recommends \
 		"postgresql-$PG_MAJOR=$PG_VERSION" \
-# https://github.com/docker-library/postgres/pull/1344#issuecomment-2936578203 (JIT is a separate package in 18+)
-		"postgresql-$PG_MAJOR-jit=$PG_VERSION" \
 	; \
+# https://github.com/docker-library/postgres/pull/1344#issuecomment-2936578203 (JIT is a separate package in 18+, but only supported for a subset of architectures)
+	if apt-get install -s "postgresql-$PG_MAJOR-jit" > /dev/null 2>&1; then \
+		apt-get install -y --no-install-recommends "postgresql-$PG_MAJOR-jit=$PG_VERSION"; \
+	fi; \
 	\
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -154,11 +154,13 @@ RUN set -ex; \
 	sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf; \
 	apt-get install -y --no-install-recommends \
 		"postgresql-$PG_MAJOR=$PG_VERSION" \
-{{ if .major >= 18 then ( -}}
-# https://github.com/docker-library/postgres/pull/1344#issuecomment-2936578203 (JIT is a separate package in 18+)
-		"postgresql-$PG_MAJOR-jit=$PG_VERSION" \
-{{ ) else "" end -}}
 	; \
+{{ if .major >= 18 then ( -}}
+# https://github.com/docker-library/postgres/pull/1344#issuecomment-2936578203 (JIT is a separate package in 18+, but only supported for a subset of architectures)
+	if apt-get install -s "postgresql-$PG_MAJOR-jit" > /dev/null 2>&1; then \
+		apt-get install -y --no-install-recommends "postgresql-$PG_MAJOR-jit=$PG_VERSION"; \
+	fi; \
+{{ ) else "" end -}}
 	\
 	rm -rf /var/lib/apt/lists/*; \
 	\


### PR DESCRIPTION
See:

- https://salsa.debian.org/postgresql/postgresql/-/commit/eaa9529d8ecb0beaeebeb5b09362dbdf4ce34c0c  
  "Make LLVM architectures a inclusion list so it works in the Architecture field."  
  (which removes i386, notably)

- https://salsa.debian.org/postgresql/postgresql/-/commit/1d6f624592d18d0cb0d694675037984f0d44b5ae
  "Disable JIT on loong64 and riscv64 again, still segfaulting."