### PR TITLE
Migrate to `setpriv` from `gosu`

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -13,38 +13,20 @@ RUN set -eux; \
 # see https://github.com/docker-library/postgres/issues/274
 	install --verbose --directory --owner postgres --group postgres --mode 1777 /var/lib/postgresql
 
-# grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.19
-RUN set -eux; \
-	\
-	apk add --no-cache --virtual .gosu-deps \
-		ca-certificates \
-		dpkg \
-		gnupg \
-	; \
-	\
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	\
-# verify the signature
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	\
-# clean up fetch dependencies
-	apk del --no-network .gosu-deps; \
-	\
-	chmod +x /usr/local/bin/gosu; \
-# verify that the binary works
-	gosu --version; \
-	gosu nobody true
 {{ if env.version | IN("14", "15", "16") then ( -}}
-RUN set -eux; ln -svf gosu /usr/local/bin/su-exec; su-exec nobody true # backwards compatibility (removed in PostgreSQL 17+)
+# backwards compatibility (removed in PostgreSQL 17+)
+RUN set -eux; \
+        \
+        apk add --no-cache su-exec; \
+        echo 'testing su-exec:' ; \
+        su-exec nobody id
 {{ ) else "" end -}}
+# Install real setpriv from util-linux rather than busybox
+RUN set -eux; \
+        \
+        apk add --no-cache setpriv; \
+        echo 'testing setpriv:' ; \
+        setpriv --reuid=nobody --regid=nobody --clear-groups id
 
 # make the "en_US.UTF-8" locale so postgres will be utf-8 enabled by default
 # alpine doesn't require explicit locale-file generation

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -20,28 +20,11 @@ RUN set -ex; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-# grab gosu for easy step-down from root
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.19
+# ensure setpriv works as expected
 RUN set -eux; \
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends ca-certificates wget; \
-	rm -rf /var/lib/apt/lists/*; \
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
+         \
+        echo 'testing setpriv:' ; \
+        setpriv --reuid=nobody --regid=nogroup --clear-groups id
 
 # make the "en_US.UTF-8" locale so postgres will be utf-8 enabled by default
 RUN set -eux; \

--- a/docker-ensure-initdb.sh
+++ b/docker-ensure-initdb.sh
@@ -27,7 +27,7 @@ docker_setup_env
 docker_create_db_directories
 if [ "$(id -u)" = '0' ]; then
 	# then restart script as postgres user
-	exec gosu postgres "$BASH_SOURCE" "$@"
+	exec setpriv --reuid=postgres --regid=postgres --clear-groups "$BASH_SOURCE" "$@"
 fi
 
 # only run initialization on an empty data directory

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -335,7 +335,7 @@ _main() {
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
 			# then restart script as postgres user
-			exec gosu postgres "$BASH_SOURCE" "$@"
+			exec setpriv --reuid=postgres --regid=postgres --clear-groups "$BASH_SOURCE" "$@"
 		fi
 
 		# only run initialization on an empty data directory


### PR DESCRIPTION
In theory this cleans up any warnings about older `gosu` binaries, uses native packaging, and remains backward compatible with the existing run scripts.

Fixes: https://github.com/docker-library/postgres/issues/1304