### PR TITLE
Remove intentionally-breaking "data" symlink and add better detection

### DIFF
--- a/13/alpine3.21/docker-entrypoint.sh
+++ b/13/alpine3.21/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/13/alpine3.22/docker-entrypoint.sh
+++ b/13/alpine3.22/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/13/bookworm/docker-entrypoint.sh
+++ b/13/bookworm/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/13/trixie/docker-entrypoint.sh
+++ b/13/trixie/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/14/alpine3.21/docker-entrypoint.sh
+++ b/14/alpine3.21/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/14/alpine3.22/docker-entrypoint.sh
+++ b/14/alpine3.22/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/14/bookworm/docker-entrypoint.sh
+++ b/14/bookworm/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/14/trixie/docker-entrypoint.sh
+++ b/14/trixie/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/15/alpine3.21/docker-entrypoint.sh
+++ b/15/alpine3.21/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/15/alpine3.22/docker-entrypoint.sh
+++ b/15/alpine3.22/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/15/bookworm/docker-entrypoint.sh
+++ b/15/bookworm/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/15/trixie/docker-entrypoint.sh
+++ b/15/trixie/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/16/alpine3.21/docker-entrypoint.sh
+++ b/16/alpine3.21/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/16/alpine3.22/docker-entrypoint.sh
+++ b/16/alpine3.22/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/16/bookworm/docker-entrypoint.sh
+++ b/16/bookworm/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/16/trixie/docker-entrypoint.sh
+++ b/16/trixie/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/17/alpine3.21/docker-entrypoint.sh
+++ b/17/alpine3.21/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/17/alpine3.22/docker-entrypoint.sh
+++ b/17/alpine3.22/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/17/bookworm/docker-entrypoint.sh
+++ b/17/bookworm/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/17/trixie/docker-entrypoint.sh
+++ b/17/trixie/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/18/alpine3.21/docker-entrypoint.sh
+++ b/18/alpine3.21/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/18/alpine3.22/docker-entrypoint.sh
+++ b/18/alpine3.22/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/18/bookworm/Dockerfile
+++ b/18/bookworm/Dockerfile
@@ -189,7 +189,6 @@ RUN install --verbose --directory --owner postgres --group postgres --mode 3777 
 # NOTE: in 18+, PGDATA has changed to match the pg_ctlcluster standard directory structure, and the VOLUME has moved from /var/lib/postgresql/data to /var/lib/postgresql
 #
 ENV PGDATA /var/lib/postgresql/18/docker
-RUN ln -svT . /var/lib/postgresql/data # https://github.com/docker-library/postgres/pull/1259#issuecomment-2215477494
 VOLUME /var/lib/postgresql
 # ("/var/lib/postgresql" is already pre-created with suitably usable permissions above)
 

--- a/18/bookworm/docker-entrypoint.sh
+++ b/18/bookworm/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/18/trixie/Dockerfile
+++ b/18/trixie/Dockerfile
@@ -189,7 +189,6 @@ RUN install --verbose --directory --owner postgres --group postgres --mode 3777 
 # NOTE: in 18+, PGDATA has changed to match the pg_ctlcluster standard directory structure, and the VOLUME has moved from /var/lib/postgresql/data to /var/lib/postgresql
 #
 ENV PGDATA /var/lib/postgresql/18/docker
-RUN ln -svT . /var/lib/postgresql/data # https://github.com/docker-library/postgres/pull/1259#issuecomment-2215477494
 VOLUME /var/lib/postgresql
 # ("/var/lib/postgresql" is already pre-created with suitably usable permissions above)
 

--- a/18/trixie/docker-entrypoint.sh
+++ b/18/trixie/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -190,7 +190,6 @@ RUN install --verbose --directory --owner postgres --group postgres --mode 3777 
 # NOTE: in 18+, PGDATA has changed to match the pg_ctlcluster standard directory structure, and the VOLUME has moved from /var/lib/postgresql/data to /var/lib/postgresql
 #
 ENV PGDATA /var/lib/postgresql/{{ .major | tostring }}/docker
-RUN ln -svT . /var/lib/postgresql/data # https://github.com/docker-library/postgres/pull/1259#issuecomment-2215477494
 VOLUME /var/lib/postgresql
 # ("/var/lib/postgresql" is already pre-created with suitably usable permissions above)
 {{ ) else ( -}}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -168,8 +168,14 @@ docker_error_old_databases() {
 			       Counter to that, there appears to be PostgreSQL data in:
 			         ${OLD_DATABASES[*]}
 
-			       This is usually the result of upgrading the Docker image without upgrading
-			       the underlying database using "pg_upgrade" (which requires both versions).
+			       This is usually the result of upgrading the Docker image without
+			       upgrading the underlying database using "pg_upgrade" (which requires both
+			       versions).
+
+			       The suggested container configuration for 18+ is to place a single mount
+			       at /var/lib/postgresql which will then place PostgreSQL data in a
+			       subdirectory, allowing usage of "pg_upgrade --link" without mount point
+			       boundary issues.
 
 			       See https://github.com/docker-library/postgres/issues/37 for a (long)
 			       discussion around this process, and suggestions for how to do so.
@@ -264,6 +270,9 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
+		fi
 	fi
 }
 


### PR DESCRIPTION
This allows for a more graceful error message for the case of users who need to update their volume path.

I tested this with 17 and `--env PGDATA=/var/lib/postgresql/17/docker` (to make sure it still works fine and doesn't complain about the extra volume provided by Docker/`VOLUME`) and 18 with `-v /var/lib/postgresql/data` (where it appropriately errors and explains to me what I should be doing instead).

I also did a reflow on some text in the error message that's designed to fit in 80 columns but was taking 81. 😂

Closes https://github.com/docker-library/postgres/issues/1363
Closes https://github.com/docker-library/postgres/issues/1364
Closes https://github.com/docker-library/postgres/issues/1370

See also:
- https://github.com/docker-library/postgres/pull/1259
- https://github.com/docker-library/docs/pull/2582
- https://github.com/docker-library/docs/pull/2624

(I was initially hesitant to implement this because I thought the implementation would be bigger, but we already had most of the scaffolding so it was really trivial.)