### PR TITLE
Fix Alpine missing `/var/lib/postgresql/data` mounts

### DIFF
--- a/14/alpine3.22/docker-entrypoint.sh
+++ b/14/alpine3.22/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/14/alpine3.23/docker-entrypoint.sh
+++ b/14/alpine3.23/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/14/bookworm/docker-entrypoint.sh
+++ b/14/bookworm/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/14/trixie/docker-entrypoint.sh
+++ b/14/trixie/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/15/alpine3.22/docker-entrypoint.sh
+++ b/15/alpine3.22/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/15/alpine3.23/docker-entrypoint.sh
+++ b/15/alpine3.23/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/15/bookworm/docker-entrypoint.sh
+++ b/15/bookworm/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/15/trixie/docker-entrypoint.sh
+++ b/15/trixie/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/16/alpine3.22/docker-entrypoint.sh
+++ b/16/alpine3.22/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/16/alpine3.23/docker-entrypoint.sh
+++ b/16/alpine3.23/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/16/bookworm/docker-entrypoint.sh
+++ b/16/bookworm/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/16/trixie/docker-entrypoint.sh
+++ b/16/trixie/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/17/alpine3.22/docker-entrypoint.sh
+++ b/17/alpine3.22/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/17/alpine3.23/docker-entrypoint.sh
+++ b/17/alpine3.23/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/17/bookworm/docker-entrypoint.sh
+++ b/17/bookworm/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/17/trixie/docker-entrypoint.sh
+++ b/17/trixie/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/18/alpine3.22/docker-entrypoint.sh
+++ b/18/alpine3.22/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/18/alpine3.23/docker-entrypoint.sh
+++ b/18/alpine3.23/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/18/bookworm/docker-entrypoint.sh
+++ b/18/bookworm/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/18/trixie/docker-entrypoint.sh
+++ b/18/trixie/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -252,7 +252,12 @@ docker_setup_env() {
 				OLD_DATABASES+=( "$d" )
 			fi
 		done
-		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && mountpoint -q /var/lib/postgresql/data; then
+		if [ "${#OLD_DATABASES[@]}" -eq 0 ] && [ "$PG_MAJOR" -ge 18 ] && {
+			# in BusyBox, "mountpoint" only checks dev vs ino (https://github.com/tianon/mirror-busybox/blob/be7d1b7b1701d225379bc1665487ed0871b592a5/util-linux/mountpoint.c#L78) which will notably miss bind mounts entirely (which almost all Docker volume mounts are)
+			# coreutils checks /proc/self/mountinfo, so we have a fallback to mimic that and directly check "/proc/self/mountinfo" to catch that case
+			mountpoint -q /var/lib/postgresql/data \
+			|| awk '$5 == "/var/lib/postgresql/data" { found = 1 } END { exit !found }' /proc/self/mountinfo
+		}; then
 			OLD_DATABASES+=( '/var/lib/postgresql/data (unused mount/volume)' )
 		fi
 	fi


### PR DESCRIPTION
This adds a `mountinfo` fallback that mimics coreutils.

- https://github.com/docker-library/postgres/issues/1400#issuecomment-4290647467

Alternatively, we could just install `coreutils` and get the "real" `mountpoint` command.

Closes #1400