### PR TITLE
Unset bootstrap credentials before exec-ing the server

### DIFF
--- a/14/alpine3.23/docker-entrypoint.sh
+++ b/14/alpine3.23/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/14/alpine3.24/docker-entrypoint.sh
+++ b/14/alpine3.24/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/14/bookworm/docker-entrypoint.sh
+++ b/14/bookworm/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/14/trixie/docker-entrypoint.sh
+++ b/14/trixie/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/15/alpine3.23/docker-entrypoint.sh
+++ b/15/alpine3.23/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/15/alpine3.24/docker-entrypoint.sh
+++ b/15/alpine3.24/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/15/bookworm/docker-entrypoint.sh
+++ b/15/bookworm/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/15/trixie/docker-entrypoint.sh
+++ b/15/trixie/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/16/alpine3.23/docker-entrypoint.sh
+++ b/16/alpine3.23/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/16/alpine3.24/docker-entrypoint.sh
+++ b/16/alpine3.24/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/16/bookworm/docker-entrypoint.sh
+++ b/16/bookworm/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/16/trixie/docker-entrypoint.sh
+++ b/16/trixie/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/17/alpine3.23/docker-entrypoint.sh
+++ b/17/alpine3.23/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/17/alpine3.24/docker-entrypoint.sh
+++ b/17/alpine3.24/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/17/bookworm/docker-entrypoint.sh
+++ b/17/bookworm/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/17/trixie/docker-entrypoint.sh
+++ b/17/trixie/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/18/alpine3.23/docker-entrypoint.sh
+++ b/18/alpine3.23/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/18/alpine3.24/docker-entrypoint.sh
+++ b/18/alpine3.24/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/18/bookworm/docker-entrypoint.sh
+++ b/18/bookworm/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/18/trixie/docker-entrypoint.sh
+++ b/18/trixie/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/19/alpine3.23/docker-entrypoint.sh
+++ b/19/alpine3.23/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/19/alpine3.24/docker-entrypoint.sh
+++ b/19/alpine3.24/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/19/bookworm/docker-entrypoint.sh
+++ b/19/bookworm/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/19/trixie/docker-entrypoint.sh
+++ b/19/trixie/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -377,6 +377,8 @@ _main() {
 
 			EOM
 		fi
+
+		unset "${!POSTGRES_@}"
 	fi
 
 	exec "$@"


### PR DESCRIPTION
POSTGRES_PASSWORD (and related vars) are only needed during initdb and the temporary-server initialisation phase. After that they serve no purpose, but remain in the process environment for the entire lifetime of the container, where any loaded C extension can read them via environ.

Unsetting them immediately before the final exec ensures the running PostgreSQL server process starts with a clean environment.